### PR TITLE
Added Help details.

### DIFF
--- a/steamgrid.go
+++ b/steamgrid.go
@@ -37,7 +37,7 @@ func startApplication() {
 		fmt.Printf("Loaded %v overlays. \n\nYou can find many user-created overlays at https://www.reddit.com/r/steamgrid/wiki/overlays .\n\n", len(overlays))
 	}
 
-	fmt.Println("Looking for Steam directory...")
+	fmt.Println("Looking for Steam directory...If SteamGrid doesn´t find the directory automatically, launch it with an argument linking to the Steam directory.")
 	installationDir, err := GetSteamInstallation()
 	if err != nil {
 		errorAndExit(err)


### PR DESCRIPTION
In the case that SteamGrid fail to find correctly the Steam directory, nothing warns the user that they could enter the directory manually themselves.
So, I’ve modified one printed line to include this.