### PR TITLE
Support the new cover format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ again when you get more games or want to update the category overlays.
 2. *(optional)* Name the overlays after your categories. So if you have a category "Games I Love", put a nice little heart overlay there named "games i love.png". You can rename the defaults that came with the zip or get new ones at [/r/steamgrid](http://www.reddit.com/r/steamgrid/wiki/overlays). Add the extension `.p` before the image extension for cover art ("games i love.p.png").
 3. *(optional)* Download a pack of custom images and place it in the `games/` folder. The image files can be either the name of the game (e.g. "Psychonauts.png") or the game id (e.g. "3830.png"). Add the extension `p` before the image extension for cover art ("Psychonauts.p.png", "3830p.png").
 4. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
-5. Read the report and open Steam in grid view to check the results.
+5. *(optional)* Generate a [SteamGridDB API Key](https://www.steamgriddb.com/profile/preferences) and run `steamgrid --steamgriddb <api key>` instead.
+6. Read the report and open Steam in grid view to check the results.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@ again when you get more games or want to update the category overlays.
 # How to use #
 
 1. Download the [latest version](https://github.com/boppreh/steamgrid/releases/latest) and extract the zip wherever.
-2. *(optional)* Name the overlays after your categories. So if you have a category "Games I Love", put a nice little heart overlay there named "games i love.png". You can rename the defaults that came with the zip or get new ones at [/r/steamgrid](http://www.reddit.com/r/steamgrid/wiki/overlays). Add the extension `.p` before the image extension for cover art ("games i love.p.png").
-3. *(optional)* Download a pack of custom images and place it in the `games/` folder. The image files can be either the name of the game (e.g. "Psychonauts.png") or the game id (e.g. "3830.png"). Add the extension `p` before the image extension for cover art ("Psychonauts.p.png", "3830p.png").
+2. *(optional)* Name the overlays after your categories. So if you have a category "Games I Love", put a nice little heart overlay there named "games i love.png". You can rename the defaults that came with the zip or get new ones at [/r/steamgrid](http://www.reddit.com/r/steamgrid/wiki/overlays).
+    * Add the extension `.p` before the image extension for cover art: `games i love.p.png`
+    * Add the extension `.hero` before the image extension for hero art `games i love.hero.png`
+    * Add the extension `.logo` before the image extension for logo art `games i love.logo.png`
+3. *(optional)* Download a pack of custom images and place it in the `games/` folder. The image files can be either the name of the game (e.g. "Psychonauts.png") or the game id (e.g. "3830.png").
+    * Add the extension `p` before the image extension for cover art: `Psychonauts.p.png`, `3830p.png`
+    * Add the extension `hero` before the image extension for hero art `Psychonauts.hero.png`, `3830_hero.png`
+    * Add the extension `logo` before the image extension for logo art `Psychonauts.logo.png`, `3830_logo.png`
 4. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
 5. *(optional)* Generate a [SteamGridDB API Key](https://www.steamgriddb.com/profile/preferences) and run `steamgrid --steamgriddb <api key>` instead.
 6. Read the report and open Steam in grid view to check the results.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ again when you get more games or want to update the category overlays.
 # How to use #
 
 1. Download the [latest version](https://github.com/boppreh/steamgrid/releases/latest) and extract the zip wherever.
-2. *(optional)* Name the overlays after your categories. So if you have a category "Games I Love", put a nice little heart overlay there named "games i love.png". You can rename the defaults that came with the zip or get new ones at [/r/steamgrid](http://www.reddit.com/r/steamgrid/wiki/overlays).
-3. *(optional)* Download a pack of custom images and place it in the `games/` folder. The image files can be either the name of the game (e.g. "Psychonauts.png") or the game id (e.g. "3830.png").
+2. *(optional)* Name the overlays after your categories. So if you have a category "Games I Love", put a nice little heart overlay there named "games i love.png". You can rename the defaults that came with the zip or get new ones at [/r/steamgrid](http://www.reddit.com/r/steamgrid/wiki/overlays). Add the extension `.p` before the image extension for cover art ("games i love.p.png").
+3. *(optional)* Download a pack of custom images and place it in the `games/` folder. The image files can be either the name of the game (e.g. "Psychonauts.png") or the game id (e.g. "3830.png"). Add the extension `p` before the image extension for cover art ("Psychonauts.p.png", "3830p.png").
 4. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
 5. Read the report and open Steam in grid view to check the results.
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,22 @@ again when you get more games or want to update the category overlays.
 # How to use #
 
 1. Download the [latest version](https://github.com/boppreh/steamgrid/releases/latest) and extract the zip wherever.
-2. *(optional)* Name the overlays after your categories. So if you have a category "Games I Love", put a nice little heart overlay there named "games i love.png". You can rename the defaults that came with the zip or get new ones at [/r/steamgrid](http://www.reddit.com/r/steamgrid/wiki/overlays).
-    * Add the extension `.p` before the image extension for cover art: `games i love.p.png`
+2. *(optional)* Name the overlays after your categories. So if you have a category "Games I Love", put a nice little heart overlay there named `games i love.banner.png`. You can rename the defaults that came with the zip or get new ones at [/r/steamgrid](http://www.reddit.com/r/steamgrid/wiki/overlays).
+    * Add the extension `.banner` before the image extension for banner art: `games i love.banner.png`
+    * Add the extension `.cover` before the image extension for cover art: `games i love.cover.png`
     * Add the extension `.hero` before the image extension for hero art `games i love.hero.png`
     * Add the extension `.logo` before the image extension for logo art `games i love.logo.png`
-3. *(optional)* Download a pack of custom images and place it in the `games/` folder. The image files can be either the name of the game (e.g. "Psychonauts.png") or the game id (e.g. "3830.png").
-    * Add the extension `p` before the image extension for cover art: `Psychonauts.p.png`, `3830p.png`
-    * Add the extension `hero` before the image extension for hero art `Psychonauts.hero.png`, `3830_hero.png`
-    * Add the extension `logo` before the image extension for logo art `Psychonauts.logo.png`, `3830_logo.png`
-4. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
-5. *(optional)* Generate a [SteamGridDB API Key](https://www.steamgriddb.com/profile/preferences) and run `steamgrid --steamgriddb <api key>` instead.
+3. *(optional)* Download a pack of custom images and place it in the `games/` folder. The image files can be either the name of the game (e.g. `Psychonauts.banner.png`) or the game id (e.g. `3830.png`).
+    * Add the extension `.banner` before the image extension for banner art: `Psychonauts.banner.png`, `3830.png`
+    * Add the extension `.cover`/`p` before the image extension for cover art: `Psychonauts.cover.png`, `3830p.png`
+    * Add the extension `.hero`/`_hero` before the image extension for hero art `Psychonauts.hero.png`, `3830_hero.png`
+    * Add the extension `.logo`/`_hero` before the image extension for logo art `Psychonauts.logo.png`, `3830_logo.png`
+4. *(optional)* Generate a some API Keys to enhance the automatic search:
+    * [SteamGridDB API Key](https://www.steamgriddb.com/profile/preferences)
+    * [IGDB API Key](https://api.igdb.com/signup)
+5. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
+    * *(optional)* Append `--steamgriddb <api key>` if you've generated one before.
+    * *(optional)* Append `--igdb <api key>` if you've genereated one before.
 6. Read the report and open Steam in grid view to check the results.
 
 ---

--- a/backup.go
+++ b/backup.go
@@ -11,27 +11,27 @@ import (
 
 // BackupGame if a game has a custom image, backs it up by appending "(original)" to the
 // file name.
-func BackupGame(gridDir string, game *Game) error {
+func BackupGame(gridDir string, game *Game, artStyleExtension string) error {
 	if game.CleanImageBytes != nil {
-		return ioutil.WriteFile(getBackupPath(gridDir, game), game.CleanImageBytes, 0666)
+		return ioutil.WriteFile(getBackupPath(gridDir, game, artStyleExtension), game.CleanImageBytes, 0666)
 	}
 	return nil
 }
 
-func getBackupPath(gridDir string, game *Game) string {
+func getBackupPath(gridDir string, game *Game, artStyleExtension string) string {
 	hash := sha256.Sum256(game.OverlayImageBytes)
 	// [:] is required to convert a fixed length byte array to a byte slice.
 	hexHash := hex.EncodeToString(hash[:])
-	return filepath.Join(gridDir, "originals", game.ID+" "+hexHash+game.ImageExt)
+	return filepath.Join(gridDir, "originals", game.ID + artStyleExtension + " " + hexHash+game.ImageExt)
 }
 
-func RemoveExisting(gridDir string, gameId string) error {
-	images, err := filepath.Glob(filepath.Join(gridDir, gameId+".*"))
+func RemoveExisting(gridDir string, gameId string, artStyleExtension string) error {
+	images, err := filepath.Glob(filepath.Join(gridDir, gameId + artStyleExtension + ".*"))
 	if err != nil {
 		return err
 	}
 
-	backups, err := filepath.Glob(filepath.Join(gridDir, "originals", gameId+" *.*"))
+	backups, err := filepath.Glob(filepath.Join(gridDir, "originals", gameId + artStyleExtension + " *.*"))
 	if err != nil {
 		return err
 	}
@@ -57,8 +57,8 @@ func loadImage(game *Game, sourceName string, imagePath string) error {
 	return err
 }
 
-func LoadExisting(overridePath string, gridDir string, game *Game) {
-	overridenIDs, _ := filepath.Glob(filepath.Join(overridePath, game.ID+".*"))
+func LoadExisting(overridePath string, gridDir string, game *Game, artStyleExtension string) {
+	overridenIDs, _ := filepath.Glob(filepath.Join(overridePath, game.ID + artStyleExtension + ".*"))
 	if overridenIDs != nil && len(overridenIDs) > 0 {
 		loadImage(game, "local file in directory 'games'", overridenIDs[0])
 		return
@@ -67,7 +67,7 @@ func LoadExisting(overridePath string, gridDir string, game *Game) {
 	if game.Name != "" {
 		re := regexp.MustCompile(`\W+`)
 		globName := re.ReplaceAllString(game.Name, "*")
-		overridenNames, _ := filepath.Glob(filepath.Join(overridePath, globName+".*"))
+		overridenNames, _ := filepath.Glob(filepath.Join(overridePath, globName + "." + artStyleExtension + ".*"))
 		if overridenNames != nil && len(overridenNames) > 0 {
 			loadImage(game, "local file in directory games/", overridenNames[0])
 			return
@@ -75,7 +75,7 @@ func LoadExisting(overridePath string, gridDir string, game *Game) {
 	}
 
 	// If there are any old-style backups (without hash), load them over the existing (with overlay) images.
-	oldBackups, err := filepath.Glob(filepath.Join(gridDir, game.ID+" (original)*"))
+	oldBackups, err := filepath.Glob(filepath.Join(gridDir, game.ID + artStyleExtension + " (original)*"))
 	if err == nil && len(oldBackups) > 0 {
 		err = loadImage(game, "legacy backup (now converted)", oldBackups[0])
 		if err == nil {
@@ -84,14 +84,14 @@ func LoadExisting(overridePath string, gridDir string, game *Game) {
 		}
 	}
 
-	files, err := filepath.Glob(filepath.Join(gridDir, game.ID+".*"))
+	files, err := filepath.Glob(filepath.Join(gridDir, game.ID + artStyleExtension + ".*"))
 	if err == nil && len(files) > 0 {
 		err = loadImage(game, "manual customization", files[0])
 		if err == nil {
 			game.OverlayImageBytes = game.CleanImageBytes
 
 			// See if there exists a backup image with no overlays or modifications.
-			loadImage(game, "backup", getBackupPath(gridDir, game))
+			loadImage(game, "backup", getBackupPath(gridDir, game, artStyleExtension))
 		}
 	}
 

--- a/backup.go
+++ b/backup.go
@@ -88,10 +88,14 @@ func LoadExisting(overridePath string, gridDir string, game *Game, artStyleExten
 	if err == nil && len(files) > 0 {
 		err = loadImage(game, "manual customization", files[0])
 		if err == nil {
+			// set as overlay to check for hash in getBackupPath()
 			game.OverlayImageBytes = game.CleanImageBytes
 
 			// See if there exists a backup image with no overlays or modifications.
 			loadImage(game, "backup", getBackupPath(gridDir, game, artStyleExtensions))
+
+			// remove overlay
+			game.OverlayImageBytes = nil
 		}
 	}
 

--- a/download.go
+++ b/download.go
@@ -18,7 +18,7 @@ import (
 // When all else fails, Google it. Uses the regular web interface. There are
 // two image search APIs, but one is deprecated and doesn't support exact size
 // matching, and the other requires an API key limited to 100 searches a day.
-const googleSearchFormat = `https://www.google.com.br/search?tbs=isz%3Aex%2Ciszw%3A%v%2Ciszh%3A%v&tbm=isch&num=5&q=`
+const googleSearchFormat = `https://www.google.com.br/search?tbs=isz%%3Aex%%2Ciszw%%3A%v%%2Ciszh%%3A%v&tbm=isch&num=5&q=`
 
 // Possible Google result formats
 var googleSearchResultPatterns = []string{`imgurl=(.+?\.(jpeg|jpg|png))&amp;imgrefurl=`, `\"ou\":\"(.+?)\",\"`}

--- a/download.go
+++ b/download.go
@@ -99,10 +99,10 @@ const SteamGridDBBaseURL = "https://www.steamgriddb.com/api/v2"
 func SteamGridDBGetRequest(url string, steamGridDBApiKey string) ([]byte, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer " + steamGridDBApiKey)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Add("Authorization", "Bearer " + steamGridDBApiKey)
 
 	response, err := client.Do(req)
 	if err != nil {

--- a/download.go
+++ b/download.go
@@ -162,19 +162,8 @@ func getSteamGridDBImage(game *Game, artStyleExtensions []string, steamGridDBApi
 
 			SteamGridDBGameId := -1
 			if jsonSearchResponse.Success && len(jsonSearchResponse.Data) >= 1 {
-				for _, n := range jsonSearchResponse.Data[0].Types {
-					for _, m := range artTypes {
-						if n == m {
-							// This game has at least one of our requested artTypes
-							SteamGridDBGameId = jsonSearchResponse.Data[0].Id
-							break
-						}
-					}
-
-					if SteamGridDBGameId != -1 {
-						break
-					}
-				}
+				// First match should be the best one
+				SteamGridDBGameId = jsonSearchResponse.Data[0].Id
 			}
 
 			if SteamGridDBGameId == -1 {

--- a/download.go
+++ b/download.go
@@ -133,22 +133,30 @@ func getSteamGridDBImage(game *Game, artStyleExtensions []string, steamGridDBApi
 		filter := steamGridFilter + "&dimensions=" + artStyleExtensions[3 + i] + "x" + artStyleExtensions[4 + i]
 
 		// Try with game.ID which is probably steams appID
-		baseUrl := SteamGridDBBaseURL
+		var baseUrl string
 		switch artStyleExtensions[1] {
 		case ".banner":
-			baseUrl = baseUrl + "/grids"
+			baseUrl = SteamGridDBBaseURL + "/grids"
 		case ".cover":
-			baseUrl = baseUrl + "/grids"
+			baseUrl = SteamGridDBBaseURL + "/grids"
 		case ".hero":
-			baseUrl = baseUrl + "/heroes"
+			baseUrl = SteamGridDBBaseURL + "/heroes"
 		case ".logo":
 			// not yet supported
 			return "", nil
 		}
 		url := baseUrl + "/steam/" + game.ID + filter
 
-		responseBytes, err := SteamGridDBGetRequest(url, steamGridDBApiKey)
 		var jsonResponse SteamGridDBResponse
+		var responseBytes []byte
+		var err error
+
+		// Skip requests with appID for custom games
+		if !game.Custom {
+			responseBytes, err = SteamGridDBGetRequest(url, steamGridDBApiKey)
+		} else {
+			err = errors.New("404")
+		}
 
 		// Authorization token is missing or invalid
 	 	if err != nil && err.Error() == "401" {

--- a/download.go
+++ b/download.go
@@ -316,7 +316,7 @@ func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []stri
 	}
 
 	url := ""
-	if steamGridDBApiKey != "" && url == "" {
+	if (artStyle == "Cover" || artStyle == "Banner") && steamGridDBApiKey != "" && url == "" {
 		from = "SteamGridDB"
 		url, err = getSteamGridDBImage(game, artStyleExtensions, steamGridDBApiKey)
 		if err != nil {

--- a/download.go
+++ b/download.go
@@ -166,7 +166,9 @@ func getSteamGridDBImage(game *Game, artStyleExtensions []string, steamGridDBApi
 			// Try searching for the name…
 			url = SteamGridDBBaseURL + "/search/autocomplete/" + game.Name + filter
 			responseBytes, err = SteamGridDBGetRequest(url, steamGridDBApiKey)
-			if err != nil {
+			if err != nil && err.Error() == "401" {
+				return "", errors.New("SteamGridDB authorization token is missing or invalid")
+			} else if err != nil {
 				return "", err
 			}
 

--- a/download.go
+++ b/download.go
@@ -151,6 +151,11 @@ func DownloadImage(gridDir string, game *Game, artStyle string) (string, error) 
 		game.ImageExt = "jpg"
 	}
 
+	if game.ImageExt == ".jpeg" {
+		// The new library ignores .jpeg
+		game.ImageExt = ".jpg"
+	}
+
 	imageBytes, err := ioutil.ReadAll(response.Body)
 	response.Body.Close()
 

--- a/download.go
+++ b/download.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -137,7 +139,7 @@ func getSteamGridDBImage(game *Game, artStyleExtensions []string, steamGridDBApi
 	var jsonResponse SteamGridDBResponse
  	if err != nil && err.Error() == "401" {
 		// Authorization token is missing or invalid
-		return "", err
+		return "", errors.New("SteamGridDB authorization token is missing or invalid")
 	} else if err != nil && err.Error() == "404" {
 		// Could not find game with that id
 
@@ -198,6 +200,80 @@ func getSteamGridDBImage(game *Game, artStyleExtensions []string, steamGridDBApi
 	return "", nil
 }
 
+const IGDBImageURL = "https://images.igdb.com/igdb/image/upload/t_720p/%v.jpg"
+const IGDBGameURL = "https://api-v3.igdb.com/games"
+const IGDBCoverURL = "https://api-v3.igdb.com/covers"
+const IGDBGameBody = `fields name,cover; search "%v";`
+const IGDBCoverBody = `fields image_id; where id = %v;`
+
+type IGDBGame struct {
+	Id int
+	Cover int
+	Name string
+}
+
+type IGDBCover struct {
+	Id int
+	Image_id string
+}
+
+func IGDBPostRequest(url string, body string, IGDBApiKey string) ([]byte, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	req.Header.Add("user-key", IGDBApiKey)
+	req.Header.Add("Accept", "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	responseBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	response.Body.Close()
+
+	return responseBytes, nil
+}
+
+func getIGDBImage(gameName string, IGDBApiKey string) (string, error) {
+	responseBytes, err := IGDBPostRequest(IGDBGameURL, fmt.Sprintf(IGDBGameBody, gameName), IGDBApiKey)
+	if err != nil {
+		return "", err
+	}
+
+	var jsonGameResponse []IGDBGame
+	err = json.Unmarshal(responseBytes, &jsonGameResponse)
+	if err != nil {
+		return "", nil
+	}
+
+	if len(jsonGameResponse) < 1 || jsonGameResponse[0].Cover == 0 {
+		return "", nil
+	}
+
+	responseBytes, err = IGDBPostRequest(IGDBCoverURL, fmt.Sprintf(IGDBCoverBody, jsonGameResponse[0].Cover), IGDBApiKey)
+	if err != nil {
+		return "", err
+	}
+
+	var jsonCoverResponse []IGDBCover
+	err = json.Unmarshal(responseBytes, &jsonCoverResponse)
+	if err != nil {
+		return "", nil
+	}
+
+	if len(jsonCoverResponse) >= 1 {
+		return fmt.Sprintf(IGDBImageURL, jsonCoverResponse[0].Image_id), nil
+	}
+
+	return "", nil
+}
+
 // Tries to fetch a URL, returning the response only if it was positive.
 func tryDownload(url string) (*http.Response, error) {
 	response, err := http.Get(url)
@@ -227,7 +303,7 @@ const steamCdnURLFormat = `cdn.akamai.steamstatic.com/steam/apps/%v/`
 // sources. Returns the final response received and a flag indicating if it was
 // from a Google search (useful because we want to log the lower quality
 // images).
-func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []string, steamGridDBApiKey string) (response *http.Response, from string, err error) {
+func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []string, steamGridDBApiKey string, IGDBApiKey string) (response *http.Response, from string, err error) {
 	from = "steam server"
 	response, err = tryDownload(fmt.Sprintf(akamaiURLFormat + artStyleExtensions[2], game.ID))
 	if err == nil && response != nil {
@@ -243,6 +319,15 @@ func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []stri
 	if steamGridDBApiKey != "" && url == "" {
 		from = "SteamGridDB"
 		url, err = getSteamGridDBImage(game, artStyleExtensions, steamGridDBApiKey)
+		if err != nil {
+			return
+		}
+	}
+
+	// IGDB has mostly cover styles
+	if artStyle == "Cover" && IGDBApiKey != "" && url == "" {
+		from = "IGDB"
+		url, err = getIGDBImage(game.Name, IGDBApiKey)
 		if err != nil {
 			return
 		}
@@ -268,8 +353,8 @@ func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []stri
 // DownloadImage tries to download the game images, saving it in game.ImageBytes. Returns
 // flags indicating if the operation succeeded and if the image downloaded was
 // from a search.
-func DownloadImage(gridDir string, game *Game, artStyle string, artStyleExtensions []string, steamGridDBApiKey string) (string, error) {
-	response, from, err := getImageAlternatives(game, artStyle, artStyleExtensions, steamGridDBApiKey)
+func DownloadImage(gridDir string, game *Game, artStyle string, artStyleExtensions []string, steamGridDBApiKey string, IGDBApiKey string) (string, error) {
+	response, from, err := getImageAlternatives(game, artStyle, artStyleExtensions, steamGridDBApiKey, IGDBApiKey)
 	if response == nil || err != nil {
 		return "", err
 	}
@@ -295,6 +380,18 @@ func DownloadImage(gridDir string, game *Game, artStyle string, artStyleExtensio
 
 	imageBytes, err := ioutil.ReadAll(response.Body)
 	response.Body.Close()
+
+	// catch false aspect ratios
+	image, _, err := image.Decode(bytes.NewBuffer(imageBytes))
+	if err != nil {
+		return "", err
+	}
+	imageSize := image.Bounds().Max
+	if (artStyle == "Banner" && imageSize.X < imageSize.Y) {
+		return "", nil
+	} else if (artStyle == "Cover" && imageSize.X > imageSize.Y) {
+		return "", nil
+	}
 
 	game.ImageSource = from;
 

--- a/download.go
+++ b/download.go
@@ -14,7 +14,8 @@ import (
 // When all else fails, Google it. Uses the regular web interface. There are
 // two image search APIs, but one is deprecated and doesn't support exact size
 // matching, and the other requires an API key limited to 100 searches a day.
-const googleSearchFormat = `https://www.google.com.br/search?tbs=isz%3Aex%2Ciszw%3A460%2Ciszh%3A215&tbm=isch&num=5&q=`
+const googleSearchFormatBanner = `https://www.google.com.br/search?tbs=isz%3Aex%2Ciszw%3A460%2Ciszh%3A215&tbm=isch&num=5&q=`
+const googleSearchFormatCover = `https://www.google.com.br/search?tbs=isz%3Aex%2Ciszw%3A600%2Ciszh%3A900&tbm=isch&num=5&q=`
 
 // Possible Google result formats
 var googleSearchResultPatterns = []string{`imgurl=(.+?\.(jpeg|jpg|png))&amp;imgrefurl=`, `\"ou\":\"(.+?)\",\"`}
@@ -26,7 +27,7 @@ func getGoogleImage(gameName string) (string, error) {
 		return "", nil
 	}
 
-	url := googleSearchFormat + url.QueryEscape(gameName)
+	url := googleSearchFormatBanner + url.QueryEscape(gameName)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
@@ -80,47 +81,63 @@ func tryDownload(url string) (*http.Response, error) {
 }
 
 // Primary URL for downloading grid images.
-const akamaiURLFormat = `https://steamcdn-a.akamaihd.net/steam/apps/%v/header.jpg`
+const akamaiURLFormatBanner = `https://steamcdn-a.akamaihd.net/steam/apps/%v/header.jpg`
+const akamaiURLFormatCover = `https://steamcdn-a.akamaihd.net/steam/apps/%v/library_600x900_2x.jpg`
 
 // The subreddit mentions this as primary, but I've found Akamai to contain
 // more images and answer faster.
-const steamCdnURLFormat = `cdn.akamai.steamstatic.com/steam/apps/%v/header.jpg`
+const steamCdnURLFormatBanner = `cdn.akamai.steamstatic.com/steam/apps/%v/header.jpg`
+const steamCdnURLFormatCover = `cdn.akamai.steamstatic.com/steam/apps/%v/library_600x900_2x.jpg`
 
 // Tries to load the grid image for a game from a number of alternative
 // sources. Returns the final response received and a flag indicating if it was
 // from a Google search (useful because we want to log the lower quality
 // images).
-func getImageAlternatives(game *Game) (response *http.Response, fromSearch bool, err error) {
-	response, err = tryDownload(fmt.Sprintf(akamaiURLFormat, game.ID))
+func getImageAlternatives(game *Game, artStyle string) (response *http.Response, from string, err error) {
+	from = "steam server"
+	if artStyle == "Banner" {
+		response, err = tryDownload(fmt.Sprintf(akamaiURLFormatBanner, game.ID))
+	} else if artStyle == "Cover" {
+		response, err = tryDownload(fmt.Sprintf(akamaiURLFormatCover, game.ID))
+	}
 	if err == nil && response != nil {
 		return
 	}
 
-	response, err = tryDownload(fmt.Sprintf(steamCdnURLFormat, game.ID))
+	if artStyle == "Banner" {
+		response, err = tryDownload(fmt.Sprintf(steamCdnURLFormatBanner, game.ID))
+	} else if artStyle == "Cover" {
+		response, err = tryDownload(fmt.Sprintf(steamCdnURLFormatCover, game.ID))
+	}
 	if err == nil && response != nil {
 		return
 	}
 
-	fromSearch = true
-	url, err := getGoogleImage(game.Name)
-	if err != nil {
-		return
+	var url string
+	// Skip for Covers
+	if artStyle != "Cover" {
+		from = "search"
+		url, err = getGoogleImage(game.Name)
+		if err != nil {
+			return
+		}
 	}
+
 	response, err = tryDownload(url)
 	if err == nil && response != nil {
 		return
 	}
 
-	return nil, false, nil
+	return nil, "", nil
 }
 
 // DownloadImage tries to download the game images, saving it in game.ImageBytes. Returns
 // flags indicating if the operation succeeded and if the image downloaded was
 // from a search.
-func DownloadImage(gridDir string, game *Game) (bool, error) {
-	response, fromSearch, err := getImageAlternatives(game)
+func DownloadImage(gridDir string, game *Game, artStyle string) (string, error) {
+	response, from, err := getImageAlternatives(game, artStyle)
 	if response == nil || err != nil {
-		return false, err
+		return "", err
 	}
 
 	contentType := response.Header.Get("Content-Type")
@@ -137,21 +154,17 @@ func DownloadImage(gridDir string, game *Game) (bool, error) {
 	imageBytes, err := ioutil.ReadAll(response.Body)
 	response.Body.Close()
 
-	if fromSearch {
-		game.ImageSource = "search"
-	} else {
-		game.ImageSource = "download"
-	}
+	game.ImageSource = from;
 
 	game.CleanImageBytes = imageBytes
-	return fromSearch, nil
+	return from, nil
 }
 
 // Get game name from SteamDB as last resort.
-const steamDBForamt = `https://steamdb.info/app/%v`
+const steamDBFormat = `https://steamdb.info/app/%v`
 
 func GetGameName(gameId string) string {
-	response, err := tryDownload(fmt.Sprintf(steamDBForamt, gameId))
+	response, err := tryDownload(fmt.Sprintf(steamDBFormat, gameId))
 	if err != nil || response == nil {
 		return ""
 	}

--- a/download.go
+++ b/download.go
@@ -30,7 +30,7 @@ func getGoogleImage(gameName string, artStyleExtensions []string) (string, error
 		return "", nil
 	}
 
-	url := fmt.Sprintf(googleSearchFormat, artStyleExtensions[3], artStyleExtensions[4]) + url.QueryEscape(gameName)
+	url := fmt.Sprintf(googleSearchFormat, artStyleExtensions[5], artStyleExtensions[6]) + url.QueryEscape(gameName)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)

--- a/games.go
+++ b/games.go
@@ -129,11 +129,13 @@ func addNonSteamGames(user User, games map[string]*Game) {
 
 // GetGames returns all games from a given user, using both the public profile and local
 // files to gather the data. Returns a map of game by ID.
-func GetGames(user User) map[string]*Game {
+func GetGames(user User, nonSteamOnly bool) map[string]*Game {
 	games := make(map[string]*Game, 0)
 
-	addGamesFromProfile(user, games)
-	addUnknownGames(user, games)
+	if !nonSteamOnly {
+		addGamesFromProfile(user, games)
+		addUnknownGames(user, games)
+	}
 	addNonSteamGames(user, games)
 
 	return games

--- a/games.go
+++ b/games.go
@@ -12,7 +12,7 @@ import (
 
 // Game in a steam library. May or may not be installed.
 type Game struct {
-	// Official Steam id.
+	// Official appID or custom shortcut ID
 	ID string
 	// Warning, may contain Unicode characters.
 	Name string
@@ -26,6 +26,8 @@ type Game struct {
 	OverlayImageBytes []byte
 	// Description of where the image was found (backup, official, search).
 	ImageSource string
+	// Is custom shortcut?
+	Custom bool
 }
 
 // Pattern of game declarations in the public profile. It's actually JSON
@@ -47,7 +49,7 @@ func addGamesFromProfile(user User, games map[string]*Game) (err error) {
 		gameID := groups[1]
 		gameName := groups[2]
 		tags := []string{""}
-		games[gameID] = &Game{gameID, gameName, tags, "", nil, nil, ""}
+		games[gameID] = &Game{gameID, gameName, tags, "", nil, nil, "", false}
 	}
 
 	return
@@ -85,7 +87,7 @@ func addUnknownGames(user User, games map[string]*Game) {
 				// If for some reason it wasn't included in the profile, create a new
 				// entry for it now. Unfortunately we don't have a name.
 				gameName := ""
-				games[gameID] = &Game{gameID, gameName, []string{tag}, "", nil, nil, ""}
+				games[gameID] = &Game{gameID, gameName, []string{tag}, "", nil, nil, "", false}
 			}
 		}
 	}
@@ -116,7 +118,7 @@ func addNonSteamGames(user User, games map[string]*Game) {
 		uniqueName := bytes.Join([][]byte{target, gameName}, []byte(""))
 		// Does IEEE CRC32 of target concatenated with gameName. No idea why Steam chose this operation.
 		gameID := strconv.FormatUint(uint64(crc32.ChecksumIEEE(uniqueName)) | 0x80000000, 10)
-		game := Game{gameID, string(gameName), []string{}, "", nil, nil, ""}
+		game := Game{gameID, string(gameName), []string{}, "", nil, nil, "", true}
 		games[gameID] = &game
 
 		tagsText := gameGroups[3]

--- a/games.go
+++ b/games.go
@@ -108,16 +108,14 @@ func addNonSteamGames(user User, games map[string]*Game) {
 
 	// The actual binary format is known, but using regexes is way easier than
 	// parsing the entire file. If I run into any problems I'll replace this.
-	gamePattern := regexp.MustCompile("(?i)appname\x00(.+?)\x00\x01exe\x00(.+?)\x00\x01.+?\x00tags\x00(.*?)\x08\x08")
+	gamePattern := regexp.MustCompile("(?i)\x00\x01appname\x00(.+?)\x00\x01exe\x00(.+?)\x00\x01.+?\x00tags\x00\x01(.*?)\x08\x08")
 	tagsPattern := regexp.MustCompile("\\d\x00(.+?)\x00")
 	for _, gameGroups := range gamePattern.FindAllSubmatch(shortcutBytes, -1) {
 		gameName := gameGroups[1]
 		target := gameGroups[2]
 		uniqueName := bytes.Join([][]byte{target, gameName}, []byte(""))
-		// Does IEEE CRC32 of target concatenated with gameName, then convert
-		// to 64bit Steam ID. No idea why Steam chose this operation.
-		top := uint64(crc32.ChecksumIEEE(uniqueName)) | 0x80000000
-		gameID := strconv.FormatUint(top<<32|0x02000000, 10)
+		// Does IEEE CRC32 of target concatenated with gameName. No idea why Steam chose this operation.
+		gameID := strconv.FormatUint(uint64(crc32.ChecksumIEEE(uniqueName)) | 0x80000000, 10)
 		game := Game{gameID, string(gameName), []string{}, "", nil, nil, ""}
 		games[gameID] = &game
 

--- a/overlays.go
+++ b/overlays.go
@@ -93,9 +93,6 @@ func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyleExtension
 		}
 
 		// We expect overlays in the correct format so we have to scale the image if it doesn't fit
-		// BannerLQ: 460 x 215
-		// BannerHQ: 920 x 430
-		// Cover: 600 x 900
 		overlaySize := overlayImage.Bounds().Max
 		result := image.NewRGBA(image.Rect(0, 0, overlaySize.X, overlaySize.Y))
 		originalSize := gameImage.Bounds().Max

--- a/overlays.go
+++ b/overlays.go
@@ -125,6 +125,7 @@ func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyleExtension
 				apngImage.Frames[i].Image = result
 				apngImage.Frames[i].XOffset = 0
 				apngImage.Frames[i].YOffset = 0
+				apngImage.Frames[i].BlendOp = apng.BLEND_OP_OVER
 			}
 			applied = true
 		} else {

--- a/overlays.go
+++ b/overlays.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"image"
-	"image/draw"
+	// "image/draw"
 	"image/jpeg"
 	"image/png"
 	"io/ioutil"
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	// "golang.org/x/image/draw"
+	"golang.org/x/image/draw"
 )
 
 // LoadOverlays from the given dir, returning a map of name -> image.
@@ -67,7 +67,7 @@ func LoadOverlays(dir string, artStyles map[string][]string) (overlays map[strin
 
 // ApplyOverlay to the game image, depending on the category. The
 // resulting image is saved over the original.
-func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyle string, artStyleExtensions []string) error {
+func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyleExtensions []string) error {
 	if game.CleanImageBytes == nil || len(game.Tags) == 0 {
 		return nil
 	}
@@ -92,17 +92,17 @@ func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyle string, 
 			continue
 		}
 
-		result := image.NewRGBA(image.Rect(0, 0, 0, 0))
-		if artStyle == "Banner" {
-			result = image.NewRGBA(image.Rect(0, 0, 920, 430))
-		} else if artStyle == "Cover" {
-			result = image.NewRGBA(image.Rect(0, 0, 600, 900))
-		}
+		// We expect overlays in the correct format so we have to scale the image if it doesn't fit
+		// BannerLQ: 460 x 215
+		// BannerHQ: 920 x 430
+		// Cover: 600 x 900
+		overlaySize := overlayImage.Bounds().Max
+		result := image.NewRGBA(image.Rect(0, 0, overlaySize.X, overlaySize.Y))
 		originalSize := gameImage.Bounds().Max
-		if ((originalSize.X != 920 && originalSize.Y != 430) || (originalSize.X != 600 && originalSize.Y != 900) && false) {
-			// scale, Steam supports high dpi
+		if (originalSize.X != overlaySize.X && originalSize.Y != overlaySize.Y) {
+			// scale to fit overlay
 			// https://godoc.org/golang.org/x/image/draw#Kernel.Scale
-			// draw.ApproxBiLinear.Scale(result, result.Bounds(), gameImage, gameImage.Bounds(), draw.Over, nil)
+			draw.ApproxBiLinear.Scale(result, result.Bounds(), gameImage, gameImage.Bounds(), draw.Over, nil)
 		} else {
 			draw.Draw(result, result.Bounds(), gameImage, image.ZP, draw.Src)
 		}

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -51,6 +51,7 @@ func startApplication() {
 	artTypes := flag.String("types", "alternate", "Comma seperated list of style types to download from SteamGridDB.\nExample: \"white_logo,material\"")
 	skipSteam := flag.Bool("skipsteam", false, "Skip downloads from Steam servers")
 	skipGoogle := flag.Bool("skipgoogle", false, "Skip search and downloads from google")
+	nonSteamOnly := flag.Bool("nonsteamonly", false, "Only search artwork for Non-Steam-Games")
 	flag.Parse()
 
 	fmt.Println("Loading overlays...")
@@ -122,7 +123,7 @@ func startApplication() {
 			errorAndExit(err)
 		}
 
-		games := GetGames(user)
+		games := GetGames(user, *nonSteamOnly)
 
 		fmt.Println("Loading existing images and backups...")
 

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -152,7 +152,7 @@ func startApplication() {
 				// Banner: favorites.png
 				// Cover: favorites.p.png
 				///////////////////////
-				err := ApplyOverlay(game, overlays, artStyle, artStyleExtensions)
+				err := ApplyOverlay(game, overlays, artStyleExtensions)
 				if err != nil {
 					print(err.Error(), "\n")
 					if artStyle == "Banner" {

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -47,6 +47,8 @@ func startApplication() {
 	steamGridDBApiKey := flag.String("steamgriddb", "", "Your personal SteamGridDB api key, get one here: https://www.steamgriddb.com/profile/preferences")
 	IGDBApiKey := flag.String("igdb", "", "Your personal IGDB api key, get one here: https://api.igdb.com/signup")
 	steamDir := flag.String("steamdir", "", "Path to your steam installation")
+	// "alternate" "blurred" "white_logo" "material" "no_logo"
+	artTypes := flag.String("types", "alternate", "Comma seperated list of style types to download from SteamGridDB.\nExample: \"white_logo,material\"")
 	flag.Parse()
 
 	fmt.Println("Loading overlays...")
@@ -157,7 +159,7 @@ func startApplication() {
 				// Download if missing.
 				///////////////////////
 				if game.ImageSource == "" {
-					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *steamGridDBApiKey, *IGDBApiKey)
+					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *steamGridDBApiKey, *artTypes, *IGDBApiKey)
 					if err != nil && err.Error() == "SteamGridDB authorization token is missing or invalid" {
 						// Wrong api key
 						*steamGridDBApiKey = ""

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -37,11 +37,11 @@ func startApplication() {
 		// HeroHQ: 3840 x 1240
 		// LogoLQ: 640 x 360
 		// LogoHQ: 1280 x 720
-		// artStyle: ["idExtension", "fileExtension", steamExtension, dimensionX, dimensionY]
-		"Banner": []string{"", ".banner", "header.jpg", "460", "215"},
-		"Cover": []string{"p", ".cover", "library_600x900_2x.jpg", "600", "900"},
-		"Hero": []string{"_hero", ".hero", "library_hero.jpg" , "3840", "1240"},
-		"Logo": []string{"_logo", ".logo", "logo.png", "1280", "720"},
+		// artStyle: ["idExtension", "nameExtension", steamExtension, dimXHQ, dimYHQ, dimXLQ, dimYLQ]
+		"Banner": []string{"", ".banner", "header.jpg", "920", "430", "460", "215"},
+		"Cover": []string{"p", ".cover", "library_600x900_2x.jpg", "600", "900", "300", "450"},
+		"Hero": []string{"_hero", ".hero", "library_hero.jpg" , "3840", "1240", "1920", "620"},
+		"Logo": []string{"_logo", ".logo", "logo.png", "1280", "720", "640", "360"},
 	}
 
 	steamGridDBApiKey := flag.String("steamgriddb", "", "Your personal SteamGridDB api key, get one here: https://www.steamgriddb.com/profile/preferences")

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -49,6 +49,8 @@ func startApplication() {
 	steamDir := flag.String("steamdir", "", "Path to your steam installation")
 	// "alternate" "blurred" "white_logo" "material" "no_logo"
 	artTypes := flag.String("types", "alternate", "Comma seperated list of style types to download from SteamGridDB.\nExample: \"white_logo,material\"")
+	skipSteam := flag.Bool("skipsteam", false, "Skip downloads from Steam servers")
+	skipGoogle := flag.Bool("skipgoogle", false, "Skip search and downloads from google")
 	flag.Parse()
 
 	fmt.Println("Loading overlays...")
@@ -159,7 +161,7 @@ func startApplication() {
 				// Download if missing.
 				///////////////////////
 				if game.ImageSource == "" {
-					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *steamGridDBApiKey, *artTypes, *IGDBApiKey)
+					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, *artTypes, *IGDBApiKey, *skipGoogle)
 					if err != nil && err.Error() == "SteamGridDB authorization token is missing or invalid" {
 						// Wrong api key
 						*steamGridDBApiKey = ""

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -172,9 +172,7 @@ func startApplication() {
 				if err != nil {
 					errorAndExit(err)
 				}
-				if game.ImageExt == ".jpeg" {
-					game.ImageExt = ".jpg"
-				}
+
 				imagePath := filepath.Join(gridDir, game.ID + artStyleExtensions[j] + game.ImageExt)
 				err = ioutil.WriteFile(imagePath, game.OverlayImageBytes, 0666)
 				if err != nil {

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -38,8 +38,8 @@ func startApplication() {
 		// LogoLQ: 640 x 360
 		// LogoHQ: 1280 x 720
 		// artStyle: ["idExtension", "fileExtension", steamExtension, dimensionX, dimensionY]
-		"Banner": []string{"", "", "header.jpg", "460", "215"},
-		"Cover": []string{"p", ".p", "library_600x900_2x.jpg", "600", "900"},
+		"Banner": []string{"", ".banner", "header.jpg", "460", "215"},
+		"Cover": []string{"p", ".cover", "library_600x900_2x.jpg", "600", "900"},
 		"Hero": []string{"_hero", ".hero", "library_hero.jpg" , "3840", "1240"},
 		"Logo": []string{"_logo", ".logo", "logo.png", "1280", "720"},
 	}

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -48,11 +48,15 @@ func startApplication() {
 	IGDBApiKey := flag.String("igdb", "", "Your personal IGDB api key, get one here: https://api.igdb.com/signup")
 	steamDir := flag.String("steamdir", "", "Path to your steam installation")
 	// "alternate" "blurred" "white_logo" "material" "no_logo"
-	artTypes := flag.String("types", "alternate", "Comma seperated list of style types to download from SteamGridDB.\nExample: \"white_logo,material\"")
+	steamGridStyles := flag.String("styles", "alternate", "Comma seperated list of styles to download from SteamGridDB.\nExample: \"white_logo,material\"")
+	// "static" "animated"
+	steamGridTypes := flag.String("types", "static", "Comma seperated list of types to download from SteamGridDB.\nExample: \"static,animated\"")
 	skipSteam := flag.Bool("skipsteam", false, "Skip downloads from Steam servers")
 	skipGoogle := flag.Bool("skipgoogle", false, "Skip search and downloads from google")
 	nonSteamOnly := flag.Bool("nonsteamonly", false, "Only search artwork for Non-Steam-Games")
 	flag.Parse()
+
+	steamGridFilter := "?styles=" + *steamGridStyles + "&types=" + *steamGridTypes
 
 	fmt.Println("Loading overlays...")
 	overlays, err := LoadOverlays(filepath.Join(filepath.Dir(os.Args[0]), "overlays by category"), artStyles)
@@ -162,7 +166,7 @@ func startApplication() {
 				// Download if missing.
 				///////////////////////
 				if game.ImageSource == "" {
-					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, *artTypes, *IGDBApiKey, *skipGoogle)
+					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, steamGridFilter, *IGDBApiKey, *skipGoogle)
 					if err != nil && err.Error() == "SteamGridDB authorization token is missing or invalid" {
 						// Wrong api key
 						*steamGridDBApiKey = ""

--- a/users.go
+++ b/users.go
@@ -113,14 +113,13 @@ func GetProfile(user User) (string, error) {
 // GetSteamInstallation Returns the Steam installation directory in Windows. Should work for
 // internationalized systems, 32 and 64 bits and users that moved their
 // ProgramFiles folder. If a folder is given by program parameter, uses that.
-func GetSteamInstallation() (path string, err error) {
-	if len(os.Args) == 2 {
-		argDir := os.Args[1]
-		_, err := os.Stat(argDir)
+func GetSteamInstallation(steamDir string) (path string, err error) {
+	if steamDir != "" {
+		_, err := os.Stat(steamDir)
 		if err == nil {
-			return argDir, nil
+			return steamDir, nil
 		}
-		return "", errors.New("Argument must be a valid Steam directory, or empty for auto detection. Got: " + argDir)
+		return "", errors.New("Argument must be a valid Steam directory, or empty for auto detection. Got: " + steamDir)
 	}
 
 	currentUser, err := user.Current()


### PR DESCRIPTION
This adds support for the new library format (600x900).
Google search is disabled because of the really bad results. We should add some additional sources like IGDB or SteamGridDB but this will need an api key as user input/parameter/config.
Apng gets preserved if no overlay is applied.

I've never done something in GO before so let me know if there's something to improve.

Fix #54 