### PR TITLE
Fixed Non-steam-games without Tags issue

### DIFF
--- a/games.go
+++ b/games.go
@@ -110,8 +110,8 @@ func addNonSteamGames(user User, games map[string]*Game) {
 
 	// The actual binary format is known, but using regexes is way easier than
 	// parsing the entire file. If I run into any problems I'll replace this.
-	gamePattern := regexp.MustCompile("(?i)\x00\x01appname\x00(.+?)\x00\x01exe\x00(.+?)\x00\x01.+?\x00tags\x00\x01(.*?)\x08\x08")
-	tagsPattern := regexp.MustCompile("\\d\x00(.+?)\x00")
+	gamePattern := regexp.MustCompile("(?i)\x00\x01appname\x00([^\x08]+?)\x00\x01exe\x00([^\x08]+?)\x00\x01[^\x08]+?\x00tags\x00(?:\x01([^\x08]+?)|)\x08\x08")
+	tagsPattern := regexp.MustCompile("\\d\x00([^\x00\x01\x08]+?)\x00")
 	for _, gameGroups := range gamePattern.FindAllSubmatch(shortcutBytes, -1) {
 		gameName := gameGroups[1]
 		target := gameGroups[2]


### PR DESCRIPTION
Great application!
I was encountering some issues with non-steam-games and thanks to this I now know some basics of the Go language as a was eager to jump into your code.

The issue explained:

When non-steam-games don't have any tags assigned to them the "tags" string is present but is only followed by a "\x00", the "\x01" is only present when tags are assigned.

This lead to a series of games being skipped until a matching "tags\x00\x01" occurred.

I've implemented two fixes:
1) prevent multiple games to be read in as one by using a negate \x08 set instead of match all.
2) grouped the \x01 and the `tag content` match in a non-capturing group