### PR TITLE
Added more arguments details

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ again when you get more games or want to update the category overlays.
 5. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
     * *(optional)* Append `--steamgriddb <api key>` if you've generated one before.
     * *(optional)* Append `--igdb <api key>` if you've genereated one before.
+    * *(optional)* Append `--types <preference>` to choose your preferences between animated steam covers or static ones Available choices : `animated`,`static`. Default : `static`. You can input both of them in order to fallback to the second option if it doesn´t found any results for the first one by separating entries with a comma. (Example : `animated,static` will result in animated covers being downloaded. If they´re none, it will search results for static one instead.
+    * *(optional)* Append `--styles <preference>` to choose your preferences between the different covers styles from steamgriddb. Available choices : `material`,`white_logo`,`alternate`,`blurred`,`no_logo`. Default: `alternate`. You can also input multiple choices in the same manners of the `--types` argument.
 6. Read the report and open Steam in grid view to check the results.
 
 ---

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ again when you get more games or want to update the category overlays.
 5. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
     * *(optional)* Append `--steamgriddb <api key>` if you've generated one before.
     * *(optional)* Append `--igdb <api key>` if you've genereated one before.
-    * *(optional)* Append `--types <preference>` to choose your preferences between animated steam covers or static ones Available choices : `animated`,`static`. Default : `static`. You can input both of them in order to fallback to the second option if it doesn´t found any results for the first one by separating entries with a comma. (Example : `animated,static` will result in animated covers being downloaded. If they´re none, it will search results for static one instead.
-    * *(optional)* Append `--styles <preference>` to choose your preferences between the different covers styles from steamgriddb. Available choices : `material`,`white_logo`,`alternate`,`blurred`,`no_logo`. Default: `alternate`. You can also input multiple choices in the same manners of the `--types` argument.
+    * *(optional)* Append `--types <preference>` to choose your preferences between animated steam covers or static ones Available choices : `animated`,`static`. Default : `static`. You can use `animated,static` to download both while preferring animated covers, and `static,animated` for preferring static covers.
+    * *(optional)* Append `--styles <preference>` to choose your preferences between the different covers styles from steamgriddb. Available choices : `material`,`white_logo`,`alternate`,`blurred`,`no_logo`. Default: `alternate`. You can also input multiple comma-separated choices in the same manners of the `--types` argument.
 6. Read the report and open Steam in grid view to check the results.
 
 ---


### PR DESCRIPTION
Just noticed that the Readme.md wasn’t updated to include the latest functions of the steamgrid program.
So I’ve added those.

However : 
— The instructions might be too over explicit or over-complicated, despite being extremely fluent in English, I tend to express myself in those manners, so this might need to be rephrased.
— I didn’t add all the available instructions from `steamgrid -h`, including this exact help argument. This can be added, of course, but you might prefer to not precise it, to keep the Readme.md description as concise as possible.