### PR TITLE
Allow downloading of missing artwork only, improved name matching and statisfy golint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ again when you get more games or want to update the category overlays.
     * *(optional)* Append `--types <preference>` to choose your preferences between animated steam covers or static ones Available choices : `animated`,`static`. Default : `static`. You can use `animated,static` to download both while preferring animated covers, and `static,animated` for preferring static covers.
     * *(optional)* Append `--styles <preference>` to choose your preferences between the different covers styles from steamgriddb. Available choices : `material`,`white_logo`,`alternate`,`blurred`,`no_logo`. Default: `alternate`. You can also input multiple comma-separated choices in the same manners of the `--types` argument.
     * *(optional)* Append `--appids <appid1,appid2>` to only process the specified appID(s)
+    * *(optional)* Append `--onlymissingartwork` to only download artworks missing on the official servers.
+    * *(tip)* Run with `--help` to see all available options.
 6. Read the report and open Steam in grid view to check the results.
 
 ---

--- a/backup.go
+++ b/backup.go
@@ -14,7 +14,7 @@ import (
 
 // BackupGame if a game has a custom image, backs it up by appending "(original)" to the
 // file name.
-func BackupGame(gridDir string, game *Game, artStyleExtensions []string) error {
+func backupGame(gridDir string, game *Game, artStyleExtensions []string) error {
 	if game.CleanImageBytes != nil {
 		return ioutil.WriteFile(getBackupPath(gridDir, game, artStyleExtensions), game.CleanImageBytes, 0666)
 	}
@@ -25,17 +25,17 @@ func getBackupPath(gridDir string, game *Game, artStyleExtensions []string) stri
 	hash := sha256.Sum256(game.OverlayImageBytes)
 	// [:] is required to convert a fixed length byte array to a byte slice.
 	hexHash := hex.EncodeToString(hash[:])
-	return filepath.Join(gridDir, "originals", game.ID + artStyleExtensions[0] + " " + hexHash+game.ImageExt)
+	return filepath.Join(gridDir, "originals", game.ID+artStyleExtensions[0]+" "+hexHash+game.ImageExt)
 }
 
-func RemoveExisting(gridDir string, gameId string, artStyleExtensions []string) error {
-	images, err := filepath.Glob(filepath.Join(gridDir, gameId + artStyleExtensions[0] + ".*"))
+func removeExisting(gridDir string, gameID string, artStyleExtensions []string) error {
+	images, err := filepath.Glob(filepath.Join(gridDir, gameID+artStyleExtensions[0]+".*"))
 	if err != nil {
 		return err
 	}
 	images = filterForImages(images)
 
-	backups, err := filepath.Glob(filepath.Join(gridDir, "originals", gameId + artStyleExtensions[0] + " *.*"))
+	backups, err := filepath.Glob(filepath.Join(gridDir, "originals", gameID+artStyleExtensions[0]+" *.*"))
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func loadImage(game *Game, sourceName string, imagePath string) error {
 }
 
 // https://wenzr.wordpress.com/2018/04/09/go-glob-case-insensitive/
-func InsensitiveFilepath(path string) string {
+func insensitiveFilepath(path string) string {
 	if runtime.GOOS == "windows" {
 		return path
 	}
@@ -95,8 +95,8 @@ func filterForImages(paths []string) []string {
 	return matchedPaths
 }
 
-func LoadExisting(overridePath string, gridDir string, game *Game, artStyleExtensions []string) {
-	overridenIDs, _ := filepath.Glob(filepath.Join(overridePath, game.ID + artStyleExtensions[0] + ".*"))
+func loadExisting(overridePath string, gridDir string, game *Game, artStyleExtensions []string) {
+	overridenIDs, _ := filepath.Glob(filepath.Join(overridePath, game.ID+artStyleExtensions[0]+".*"))
 	if overridenIDs != nil && len(overridenIDs) > 0 {
 		loadImage(game, "local file in directory 'games'", overridenIDs[0])
 		return
@@ -106,7 +106,7 @@ func LoadExisting(overridePath string, gridDir string, game *Game, artStyleExten
 	if game.Name != "" {
 		re := regexp.MustCompile(`\W+`)
 		globName := re.ReplaceAllString(game.Name, "*")
-		overridenNames, _ := filepath.Glob(filepath.Join(overridePath, InsensitiveFilepath(globName) + artStyleExtensions[1] + ".*"))
+		overridenNames, _ := filepath.Glob(filepath.Join(overridePath, insensitiveFilepath(globName)+artStyleExtensions[1]+".*"))
 		if overridenNames != nil && len(overridenNames) > 0 {
 			loadImage(game, "local file in directory games/", overridenNames[0])
 			return
@@ -114,7 +114,7 @@ func LoadExisting(overridePath string, gridDir string, game *Game, artStyleExten
 	}
 
 	// If there are any old-style backups (without hash), load them over the existing (with overlay) images.
-	oldBackups, err := filepath.Glob(filepath.Join(gridDir, game.ID + artStyleExtensions[0] + " (original)*"))
+	oldBackups, err := filepath.Glob(filepath.Join(gridDir, game.ID+artStyleExtensions[0]+" (original)*"))
 	if err == nil && len(oldBackups) > 0 {
 		err = loadImage(game, "legacy backup (now converted)", oldBackups[0])
 		if err == nil {
@@ -123,7 +123,7 @@ func LoadExisting(overridePath string, gridDir string, game *Game, artStyleExten
 		}
 	}
 
-	files, err := filepath.Glob(filepath.Join(gridDir, game.ID + artStyleExtensions[0] + ".*"))
+	files, err := filepath.Glob(filepath.Join(gridDir, game.ID+artStyleExtensions[0]+".*"))
 	files = filterForImages(files)
 	if err == nil && len(files) > 0 {
 		err = loadImage(game, "manual customization", files[0])

--- a/download.go
+++ b/download.go
@@ -179,8 +179,18 @@ func getSteamGridDBImage(game *Game, artStyleExtensions []string, steamGridDBApi
 
 			SteamGridDBGameID := -1
 			if jsonSearchResponse.Success && len(jsonSearchResponse.Data) >= 1 {
-				// First match should be the best one
-				SteamGridDBGameID = jsonSearchResponse.Data[0].ID
+				// try to get exact match
+				for i := 0; i < len(jsonSearchResponse.Data); i++ {
+					if jsonSearchResponse.Data[i].Name == game.Name {
+						SteamGridDBGameID = jsonSearchResponse.Data[i].ID
+						break
+					}
+				}
+
+				// else guess first result
+				if SteamGridDBGameID == -1 {
+					SteamGridDBGameID = jsonSearchResponse.Data[0].ID
+				}
 			}
 
 			if SteamGridDBGameID == -1 {

--- a/download.go
+++ b/download.go
@@ -313,16 +313,24 @@ const steamCdnURLFormat = `cdn.akamai.steamstatic.com/steam/apps/%v/`
 // sources. Returns the final response received and a flag indicating if it was
 // from a Google search (useful because we want to log the lower quality
 // images).
-func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, steamGridFilter string, IGDBApiKey string, skipGoogle bool) (response *http.Response, from string, err error) {
+func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, steamGridFilter string, IGDBApiKey string, skipGoogle bool, onlyMissingArtwork bool) (response *http.Response, from string, err error) {
 	from = "steam server"
 	if !skipSteam {
 		response, err = tryDownload(fmt.Sprintf(akamaiURLFormat+artStyleExtensions[2], game.ID))
 		if err == nil && response != nil {
+			if onlyMissingArtwork {
+				// Abort if image is available
+				return nil, "", nil
+			}
 			return
 		}
 
 		response, err = tryDownload(fmt.Sprintf(steamCdnURLFormat+artStyleExtensions[2], game.ID))
 		if err == nil && response != nil {
+			if onlyMissingArtwork {
+				// Abort if image is available
+				return nil, "", nil
+			}
 			return
 		}
 	}
@@ -365,8 +373,8 @@ func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []stri
 // DownloadImage tries to download the game images, saving it in game.ImageBytes. Returns
 // flags indicating if the operation succeeded and if the image downloaded was
 // from a search.
-func DownloadImage(gridDir string, game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, steamGridFilter string, IGDBApiKey string, skipGoogle bool) (string, error) {
-	response, from, err := getImageAlternatives(game, artStyle, artStyleExtensions, skipSteam, steamGridDBApiKey, steamGridFilter, IGDBApiKey, skipGoogle)
+func DownloadImage(gridDir string, game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, steamGridFilter string, IGDBApiKey string, skipGoogle bool, onlyMissingArtwork bool) (string, error) {
+	response, from, err := getImageAlternatives(game, artStyle, artStyleExtensions, skipSteam, steamGridDBApiKey, steamGridFilter, IGDBApiKey, skipGoogle, onlyMissingArtwork)
 	if response == nil || err != nil {
 		return "", err
 	}

--- a/download.go
+++ b/download.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deanishe/awgo/fuzzy"
+	"go.deanishe.net/fuzzy"
 )
 
 // When all else fails, Google it. Uses the regular web interface. There are

--- a/games.go
+++ b/games.go
@@ -118,7 +118,7 @@ func addNonSteamGames(user User, games map[string]*Game) {
 		target := gameGroups[2]
 		uniqueName := bytes.Join([][]byte{target, gameName}, []byte(""))
 		// Does IEEE CRC32 of target concatenated with gameName. No idea why Steam chose this operation.
-		gameID := strconv.FormatUint(uint64(crc32.ChecksumIEEE(uniqueName)) | 0x80000000, 10)
+		gameID := strconv.FormatUint(uint64(crc32.ChecksumIEEE(uniqueName))|0x80000000, 10)
 		game := Game{gameID, string(gameName), []string{}, "", nil, nil, "", true}
 		games[gameID] = &game
 

--- a/games.go
+++ b/games.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"bytes"
+	"encoding/binary"
+	"fmt"
 	"hash/crc32"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 )
 
@@ -29,6 +30,8 @@ type Game struct {
 	ImageSource string
 	// Is custom shortcut?
 	Custom bool
+	// LegacyID used in BigPicture
+	LegacyID uint64
 }
 
 // Pattern of game declarations in the public profile. It's actually JSON
@@ -50,7 +53,7 @@ func addGamesFromProfile(user User, games map[string]*Game) (err error) {
 		gameID := groups[1]
 		gameName := groups[2]
 		tags := []string{""}
-		games[gameID] = &Game{gameID, gameName, tags, "", nil, nil, "", false}
+		games[gameID] = &Game{gameID, gameName, tags, "", nil, nil, "", false, 0}
 	}
 
 	return
@@ -88,7 +91,7 @@ func addUnknownGames(user User, games map[string]*Game) {
 				// If for some reason it wasn't included in the profile, create a new
 				// entry for it now. Unfortunately we don't have a name.
 				gameName := ""
-				games[gameID] = &Game{gameID, gameName, []string{tag}, "", nil, nil, "", false}
+				games[gameID] = &Game{gameID, gameName, []string{tag}, "", nil, nil, "", false, 0}
 			}
 		}
 	}
@@ -111,18 +114,21 @@ func addNonSteamGames(user User, games map[string]*Game) {
 
 	// The actual binary format is known, but using regexes is way easier than
 	// parsing the entire file. If I run into any problems I'll replace this.
-	gamePattern := regexp.MustCompile("(?i)\x01appname\x00([^\x08]+?)\x00\x01exe\x00([^\x08]+?)\x00\x01.+?\x00tags\x00(?:\x01([^\x08]+?)|)\x08\x08")
+	gamePattern := regexp.MustCompile("(?i)\x00\x02appid\x00(.{4})\x01appname\x00([^\x08]+?)\x00\x01exe\x00([^\x08]+?)\x00\x01.+?\x00tags\x00(?:\x01([^\x08]+?)|)\x08\x08")
 	tagsPattern := regexp.MustCompile("\\d\x00([^\x00\x01\x08]+?)\x00")
 	for _, gameGroups := range gamePattern.FindAllSubmatch(shortcutBytes, -1) {
-		gameName := gameGroups[1]
-		target := gameGroups[2]
+		gameID := fmt.Sprint(binary.LittleEndian.Uint32(gameGroups[1]))
+		gameName := gameGroups[2]
+
+		// BigPicture is still using these
+		target := gameGroups[3]
 		uniqueName := bytes.Join([][]byte{target, gameName}, []byte(""))
-		// Does IEEE CRC32 of target concatenated with gameName. No idea why Steam chose this operation.
-		gameID := strconv.FormatUint(uint64(crc32.ChecksumIEEE(uniqueName))|0x80000000, 10)
-		game := Game{gameID, string(gameName), []string{}, "", nil, nil, "", true}
+		LegacyID := uint64(crc32.ChecksumIEEE(uniqueName)) | 0x80000000
+
+		game := Game{gameID, string(gameName), []string{}, "", nil, nil, "", true, LegacyID}
 		games[gameID] = &game
 
-		tagsText := gameGroups[3]
+		tagsText := gameGroups[4]
 		for _, tagGroups := range tagsPattern.FindAllSubmatch(tagsText, -1) {
 			tag := tagGroups[1]
 			game.Tags = append(game.Tags, string(tag))
@@ -137,7 +143,7 @@ func GetGames(user User, nonSteamOnly bool, appIDs string) map[string]*Game {
 
 	if appIDs != "" {
 		for _, appID := range strings.Split(appIDs, ",") {
-			games[appID] = &Game{appID, "", []string{}, "", nil, nil, "", false}
+			games[appID] = &Game{appID, "", []string{}, "", nil, nil, "", false, 0}
 		}
 		return games
 	}

--- a/overlays.go
+++ b/overlays.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"image"
+
 	// "image/draw"
 	"image/jpeg"
 	"image/png"
@@ -11,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/image/draw"
 	"github.com/kettek/apng"
+	"golang.org/x/image/draw"
 )
 
 // LoadOverlays from the given dir, returning a map of name -> image.
@@ -99,7 +100,7 @@ func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyleExtension
 		tagName = strings.Replace(tagName, ">", "-", -1)
 		tagName = strings.Replace(tagName, "/", "-", -1)
 
-		overlayImage, ok := overlays[tagName + artStyleExtensions[1]]
+		overlayImage, ok := overlays[tagName+artStyleExtensions[1]]
 		if !ok {
 			continue
 		}
@@ -113,7 +114,7 @@ func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyleExtension
 				// Scale overlay to imageSize so the images won't get that huge…
 				overlayScaled := image.NewRGBA(image.Rect(0, 0, originalSize.X, originalSize.Y))
 				result := image.NewRGBA(image.Rect(0, 0, originalSize.X, originalSize.Y))
-				if (originalSize.X != overlaySize.X && originalSize.Y != overlaySize.Y) {
+				if originalSize.X != overlaySize.X && originalSize.Y != overlaySize.Y {
 					// https://godoc.org/golang.org/x/image/draw#Kernel.Scale
 					draw.ApproxBiLinear.Scale(overlayScaled, overlayScaled.Bounds(), overlayImage, overlayImage.Bounds(), draw.Over, nil)
 				} else {
@@ -133,7 +134,7 @@ func ApplyOverlay(game *Game, overlays map[string]image.Image, artStyleExtension
 
 			// We expect overlays in the correct format so we have to scale the image if it doesn't fit
 			result := image.NewRGBA(image.Rect(0, 0, overlaySize.X, overlaySize.Y))
-			if (originalSize.X != overlaySize.X && originalSize.Y != overlaySize.Y) {
+			if originalSize.X != overlaySize.X && originalSize.Y != overlaySize.Y {
 				// scale to fit overlay
 				// https://godoc.org/golang.org/x/image/draw#Kernel.Scale
 				draw.ApproxBiLinear.Scale(result, result.Bounds(), gameImage, gameImage.Bounds(), draw.Over, nil)

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -83,7 +83,11 @@ func startApplication() {
 		delete(artStyles, "Logo")
 	}
 	if len(artStyles) == 0 {
-		errorAndExit(errors.New("No artStyes, nothing to do…"))
+		errorAndExit(errors.New("No artStyles, nothing to do…"))
+	}
+
+	if *skipSteam && *onlyMissingArtwork {
+		errorAndExit(errors.New("Can't check if official artwork is missing with steam turned off"))
 	}
 
 	fmt.Println("Loading overlays...")

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -59,6 +59,7 @@ func startApplication() {
 	skipLogo := flag.Bool("skiplogo", false, "Skip search and processing logo artwork")
 	nonSteamOnly := flag.Bool("nonsteamonly", false, "Only search artwork for Non-Steam-Games")
 	appIDs := flag.String("appids", "", "Comma separated list of appIds that should be processed")
+	onlyMissingArtwork := flag.Bool("onlymissingartwork", false, "Only download artworks missing on the official servers")
 	flag.Parse()
 	if flag.NArg() == 1 {
 		steamDir = &flag.Args()[0]
@@ -193,7 +194,7 @@ func startApplication() {
 				// Download if missing.
 				///////////////////////
 				if game.ImageSource == "" {
-					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, steamGridFilter, *IGDBApiKey, *skipGoogle)
+					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, steamGridFilter, *IGDBApiKey, *skipGoogle, *onlyMissingArtwork)
 					if err != nil && err.Error() == "SteamGridDB authorization token is missing or invalid" {
 						// Wrong api key
 						*steamGridDBApiKey = ""

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -39,9 +39,9 @@ func startApplication() {
 		// LogoHQ: 1280 x 720
 		// artStyle: ["idExtension", "nameExtension", steamExtension, dimXHQ, dimYHQ, dimXLQ, dimYLQ]
 		"Banner": []string{"", ".banner", "header.jpg", "920", "430", "460", "215"},
-		"Cover": []string{"p", ".cover", "library_600x900_2x.jpg", "600", "900", "300", "450"},
-		"Hero": []string{"_hero", ".hero", "library_hero.jpg" , "3840", "1240", "1920", "620"},
-		"Logo": []string{"_logo", ".logo", "logo.png", "1280", "720", "640", "360"},
+		"Cover":  []string{"p", ".cover", "library_600x900_2x.jpg", "600", "900", "300", "450"},
+		"Hero":   []string{"_hero", ".hero", "library_hero.jpg", "3840", "1240", "1920", "620"},
+		"Logo":   []string{"_logo", ".logo", "logo.png", "1280", "720", "640", "360"},
 	}
 
 	steamGridDBApiKey := flag.String("steamgriddb", "", "Your personal SteamGridDB api key, get one here: https://www.steamgriddb.com/profile/preferences")
@@ -91,7 +91,7 @@ func startApplication() {
 		errorAndExit(err)
 	}
 	if len(overlays) == 0 {
-		fmt.Println("No category overlays found. You can put overlay images in the folder 'overlays by category', where the filename is the game category.\n\nYou can find many user-created overlays at https://www.reddit.com/r/steamgrid/wiki/overlays .\n\nContinuing without overlays...\n")
+		fmt.Println("No category overlays found. You can put overlay images in the folder 'overlays by category', where the filename is the game category.\n\nYou can find many user-created overlays at https://www.reddit.com/r/steamgrid/wiki/overlays .\n\nContinuing without overlays...")
 	} else {
 		fmt.Printf("Loaded %v overlays. \n\nYou can find many user-created overlays at https://www.reddit.com/r/steamgrid/wiki/overlays .\n\n", len(overlays))
 	}
@@ -115,33 +115,33 @@ func startApplication() {
 	nDownloaded := 0
 	notFounds := map[string][]*Game{
 		"Banner": []*Game{},
-		"Cover": []*Game{},
-		"Hero": []*Game{},
-		"Logo": []*Game{},
+		"Cover":  []*Game{},
+		"Hero":   []*Game{},
+		"Logo":   []*Game{},
 	}
 	steamGridDB := map[string][]*Game{
 		"Banner": []*Game{},
-		"Cover": []*Game{},
-		"Hero": []*Game{},
-		"Logo": []*Game{},
+		"Cover":  []*Game{},
+		"Hero":   []*Game{},
+		"Logo":   []*Game{},
 	}
 	IGDB := map[string][]*Game{
 		"Banner": []*Game{},
-		"Cover": []*Game{},
-		"Hero": []*Game{},
-		"Logo": []*Game{},
+		"Cover":  []*Game{},
+		"Hero":   []*Game{},
+		"Logo":   []*Game{},
 	}
 	searchedGames := map[string][]*Game{
 		"Banner": []*Game{},
-		"Cover": []*Game{},
-		"Hero": []*Game{},
-		"Logo": []*Game{},
+		"Cover":  []*Game{},
+		"Hero":   []*Game{},
+		"Logo":   []*Game{},
 	}
 	failedGames := map[string][]*Game{
 		"Banner": []*Game{},
-		"Cover": []*Game{},
-		"Hero": []*Game{},
-		"Logo": []*Game{},
+		"Cover":  []*Game{},
+		"Hero":   []*Game{},
+		"Logo":   []*Game{},
 	}
 	var errorMessages []string
 
@@ -164,7 +164,7 @@ func startApplication() {
 
 			var name string
 			if game.Name == "" {
-				game.Name = GetGameName(game.ID)
+				game.Name = getGameName(game.ID)
 			}
 
 			if game.Name != "" {
@@ -182,9 +182,9 @@ func startApplication() {
 				game.OverlayImageBytes = nil
 
 				overridePath := filepath.Join(filepath.Dir(os.Args[0]), "games")
-				LoadExisting(overridePath, gridDir, game, artStyleExtensions)
+				loadExisting(overridePath, gridDir, game, artStyleExtensions)
 				// This cleans up unused backups and images for the same game but with different extensions.
-				err = RemoveExisting(gridDir, game.ID, artStyleExtensions)
+				err = removeExisting(gridDir, game.ID, artStyleExtensions)
 				if err != nil {
 					fmt.Println(err.Error())
 				}
@@ -246,19 +246,19 @@ func startApplication() {
 				///////////////////////
 				// Save result.
 				///////////////////////
-				err = BackupGame(gridDir, game, artStyleExtensions)
+				err = backupGame(gridDir, game, artStyleExtensions)
 				if err != nil {
 					errorAndExit(err)
 				}
 
-				imagePath := filepath.Join(gridDir, game.ID + artStyleExtensions[0] + game.ImageExt)
+				imagePath := filepath.Join(gridDir, game.ID+artStyleExtensions[0]+game.ImageExt)
 				err = ioutil.WriteFile(imagePath, game.OverlayImageBytes, 0666)
 
 				// Copy with legacy naming for Big Picture mode
 				if artStyle == "Banner" {
 					id, err := strconv.ParseUint(game.ID, 10, 64)
 					if err == nil {
-						imagePath := filepath.Join(gridDir, strconv.FormatUint(id<<32|0x02000000, 10) + artStyleExtensions[0] + game.ImageExt)
+						imagePath := filepath.Join(gridDir, strconv.FormatUint(id<<32|0x02000000, 10)+artStyleExtensions[0]+game.ImageExt)
 						err = ioutil.WriteFile(imagePath, game.OverlayImageBytes, 0666)
 					}
 				}
@@ -270,8 +270,8 @@ func startApplication() {
 	}
 
 	fmt.Printf("\n\n%v images downloaded and %v overlays applied.\n\n", nDownloaded, nOverlaysApplied)
-	if len(searchedGames["Banner"]) + len(searchedGames["Cover"]) + len(searchedGames["Hero"]) + len(searchedGames["Logo"]) >= 1 {
-		fmt.Printf("%v images were found with a Google search and may not be accurate:\n", len(searchedGames["Banner"]) + len(searchedGames["Cover"]) + len(searchedGames["Hero"]) + len(searchedGames["Logo"]))
+	if len(searchedGames["Banner"])+len(searchedGames["Cover"])+len(searchedGames["Hero"])+len(searchedGames["Logo"]) >= 1 {
+		fmt.Printf("%v images were found with a Google search and may not be accurate:\n", len(searchedGames["Banner"])+len(searchedGames["Cover"])+len(searchedGames["Hero"])+len(searchedGames["Logo"]))
 		for artStyle, games := range searchedGames {
 			for _, game := range games {
 				fmt.Printf("* %v (steam id %v, %v)\n", game.Name, game.ID, artStyle)
@@ -281,8 +281,8 @@ func startApplication() {
 		fmt.Printf("\n\n")
 	}
 
-	if len(IGDB["Banner"]) + len(IGDB["Cover"]) >= 1 {
-		fmt.Printf("%v images were found on IGDB and may not be in full quality or accurate:\n", len(IGDB["Banner"]) + len(IGDB["Cover"]))
+	if len(IGDB["Banner"])+len(IGDB["Cover"]) >= 1 {
+		fmt.Printf("%v images were found on IGDB and may not be in full quality or accurate:\n", len(IGDB["Banner"])+len(IGDB["Cover"]))
 		for artStyle, games := range IGDB {
 			for _, game := range games {
 				fmt.Printf("* %v (steam id %v, %v)\n", game.Name, game.ID, artStyle)
@@ -292,8 +292,8 @@ func startApplication() {
 		fmt.Printf("\n\n")
 	}
 
-	if len(steamGridDB["Banner"]) + len(steamGridDB["Cover"]) + len(steamGridDB["Hero"]) + len(steamGridDB["Logo"]) >= 1 {
-		fmt.Printf("%v images were found on SteamGridDB and may not be in full quality or accurate:\n", len(steamGridDB["Banner"]) + len(steamGridDB["Cover"]) + len(steamGridDB["Hero"]) + len(steamGridDB["Logo"]))
+	if len(steamGridDB["Banner"])+len(steamGridDB["Cover"])+len(steamGridDB["Hero"])+len(steamGridDB["Logo"]) >= 1 {
+		fmt.Printf("%v images were found on SteamGridDB and may not be in full quality or accurate:\n", len(steamGridDB["Banner"])+len(steamGridDB["Cover"])+len(steamGridDB["Hero"])+len(steamGridDB["Logo"]))
 		for artStyle, games := range steamGridDB {
 			for _, game := range games {
 				fmt.Printf("* %v (steam id %v, %v)\n", game.Name, game.ID, artStyle)
@@ -303,8 +303,8 @@ func startApplication() {
 		fmt.Printf("\n\n")
 	}
 
-	if len(notFounds["Banner"]) + len(notFounds["Cover"]) + len(notFounds["Hero"]) + len(notFounds["Logo"]) >= 1 {
-		fmt.Printf("%v images could not be found anywhere:\n", len(notFounds["Banner"]) + len(notFounds["Cover"]) + len(notFounds["Hero"]) + len(notFounds["Logo"]))
+	if len(notFounds["Banner"])+len(notFounds["Cover"])+len(notFounds["Hero"])+len(notFounds["Logo"]) >= 1 {
+		fmt.Printf("%v images could not be found anywhere:\n", len(notFounds["Banner"])+len(notFounds["Cover"])+len(notFounds["Hero"])+len(notFounds["Logo"]))
 		for artStyle, games := range notFounds {
 			for _, game := range games {
 				fmt.Printf("- %v (id %v, %v)\n", game.Name, game.ID, artStyle)
@@ -314,8 +314,8 @@ func startApplication() {
 		fmt.Printf("\n\n")
 	}
 
-	if len(failedGames["Banner"]) + len(failedGames["Cover"]) + len(failedGames["Hero"]) + len(failedGames["Logo"]) >= 1 {
-		fmt.Printf("%v images were found but had errors and could not be overlaid:\n", len(failedGames["Banner"]) + len(failedGames["Cover"]) + len(failedGames["Hero"]) + len(failedGames["Logo"]))
+	if len(failedGames["Banner"])+len(failedGames["Cover"])+len(failedGames["Hero"])+len(failedGames["Logo"]) >= 1 {
+		fmt.Printf("%v images were found but had errors and could not be overlaid:\n", len(failedGames["Banner"])+len(failedGames["Cover"])+len(failedGames["Hero"])+len(failedGames["Logo"]))
 		for artStyle, games := range failedGames {
 			var i = 0
 			for _, game := range games {

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -263,7 +263,12 @@ func startApplication() {
 
 				// Copy with legacy naming for Big Picture mode
 				if artStyle == "Banner" {
+					// use appID
 					id, err := strconv.ParseUint(game.ID, 10, 64)
+					if game.LegacyID != 0 {
+						// old target+exe format for custom shortcuts
+						id = game.LegacyID
+					}
 					if err == nil {
 						imagePath := filepath.Join(gridDir, strconv.FormatUint(id<<32|0x02000000, 10)+artStyleExtensions[0]+game.ImageExt)
 						err = ioutil.WriteFile(imagePath, game.OverlayImageBytes, 0666)

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -51,6 +51,8 @@ func startApplication() {
 	steamGridStyles := flag.String("styles", "alternate", "Comma separated list of styles to download from SteamGridDB.\nExample: \"white_logo,material\"")
 	// "static" "animated"
 	steamGridTypes := flag.String("types", "static", "Comma separated list of types to download from SteamGridDB.\nExample: \"static,animated\"")
+	steamGridNsfw := flag.String("nsfw", "false", "Set to false to filter out nsfw, true to only include nsfw, any to include both.")
+	steamGridHumor := flag.String("humor", "false", "Set to false to filter out humor, true to only include humor, any to include both.")
 	skipSteam := flag.Bool("skipsteam", false, "Skip downloads from Steam servers")
 	skipGoogle := flag.Bool("skipgoogle", false, "Skip search and downloads from google")
 	skipBanner := flag.Bool("skipbanner", false, "Skip search and processing banner artwork")
@@ -69,7 +71,7 @@ func startApplication() {
 	}
 
 	// Process command line flags
-	steamGridFilter := "?styles=" + *steamGridStyles + "&types=" + *steamGridTypes
+	steamGridFilter := "?styles=" + *steamGridStyles + "&types=" + *steamGridTypes + "&nsfw=" + *steamGridNsfw + "&humor=" + *steamGridHumor
 	if *skipBanner {
 		delete(artStyles, "Banner")
 	}

--- a/users.go
+++ b/users.go
@@ -93,7 +93,7 @@ func GetProfile(user User) (string, error) {
 	}
 
 	if response.StatusCode >= 400 {
-		return "", errors.New("Profile not found. Make sure you have a public Steam profile.")
+		return "", errors.New("Profile not found. Make sure you have a public Steam profile")
 	}
 
 	contentBytes, err := ioutil.ReadAll(response.Body)
@@ -104,7 +104,7 @@ func GetProfile(user User) (string, error) {
 
 	profile := string(contentBytes)
 	if strings.Contains(profile, steamProfileErrorMessage) {
-		return "", errors.New("Profile not found.")
+		return "", errors.New("Profile not found")
 	}
 
 	return profile, nil
@@ -150,5 +150,5 @@ func GetSteamInstallation(steamDir string) (path string, err error) {
 		return programFilesDir, nil
 	}
 
-	return "", errors.New("Could not find Steam installation folder. You can drag and drop the Steam folder into `steamgrid.exe` or call `steamgrid STEAMPATH` for a manual override.")
+	return "", errors.New("Could not find Steam installation folder. You can drag and drop the Steam folder into `steamgrid.exe` or call `steamgrid STEAMPATH` for a manual override")
 }


### PR DESCRIPTION
Adds the option `--onlymissingartwork` to only download and cache artwork that is missing on the official steam servers and won't be cached automatically by the steam client.
Fixes #68

Fuzzy sorting before taking the first result of steamgriddbs autocomplete search.
Fixes #70

Golint suggests a few things to improve quality. I've almost accepted everything because the tool know probably better than me.

Adapts to new shortcut IDs.
Fixes #85 
Fixes #86 