### PR TITLE
Add command line parameter appids

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ again when you get more games or want to update the category overlays.
     * *(optional)* Append `--igdb <api key>` if you've genereated one before.
     * *(optional)* Append `--types <preference>` to choose your preferences between animated steam covers or static ones Available choices : `animated`,`static`. Default : `static`. You can use `animated,static` to download both while preferring animated covers, and `static,animated` for preferring static covers.
     * *(optional)* Append `--styles <preference>` to choose your preferences between the different covers styles from steamgriddb. Available choices : `material`,`white_logo`,`alternate`,`blurred`,`no_logo`. Default: `alternate`. You can also input multiple comma-separated choices in the same manners of the `--types` argument.
+    * *(optional)* Append `--appids <appid1,appid2>` to only process the specified appID(s)
 6. Read the report and open Steam in grid view to check the results.
 
 ---

--- a/games.go
+++ b/games.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // Game in a steam library. May or may not be installed.
@@ -131,8 +132,15 @@ func addNonSteamGames(user User, games map[string]*Game) {
 
 // GetGames returns all games from a given user, using both the public profile and local
 // files to gather the data. Returns a map of game by ID.
-func GetGames(user User, nonSteamOnly bool) map[string]*Game {
+func GetGames(user User, nonSteamOnly bool, appIDs string) map[string]*Game {
 	games := make(map[string]*Game, 0)
+
+	if appIDs != "" {
+		for _, appID := range strings.Split(appIDs, ",") {
+			games[appID] = &Game{appID, "", []string{}, "", nil, nil, "", false}
+		}
+		return games
+	}
 
 	if !nonSteamOnly {
 		addGamesFromProfile(user, games)

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -48,9 +48,9 @@ func startApplication() {
 	IGDBApiKey := flag.String("igdb", "", "Your personal IGDB api key, get one here: https://api.igdb.com/signup")
 	steamDir := flag.String("steamdir", "", "Path to your steam installation")
 	// "alternate" "blurred" "white_logo" "material" "no_logo"
-	steamGridStyles := flag.String("styles", "alternate", "Comma seperated list of styles to download from SteamGridDB.\nExample: \"white_logo,material\"")
+	steamGridStyles := flag.String("styles", "alternate", "Comma separated list of styles to download from SteamGridDB.\nExample: \"white_logo,material\"")
 	// "static" "animated"
-	steamGridTypes := flag.String("types", "static", "Comma seperated list of types to download from SteamGridDB.\nExample: \"static,animated\"")
+	steamGridTypes := flag.String("types", "static", "Comma separated list of types to download from SteamGridDB.\nExample: \"static,animated\"")
 	skipSteam := flag.Bool("skipsteam", false, "Skip downloads from Steam servers")
 	skipGoogle := flag.Bool("skipgoogle", false, "Skip search and downloads from google")
 	skipBanner := flag.Bool("skipbanner", false, "Skip search and processing banner artwork")
@@ -58,6 +58,7 @@ func startApplication() {
 	skipHero := flag.Bool("skiphero", false, "Skip search and processing hero artwork")
 	skipLogo := flag.Bool("skiplogo", false, "Skip search and processing logo artwork")
 	nonSteamOnly := flag.Bool("nonsteamonly", false, "Only search artwork for Non-Steam-Games")
+	appIDs := flag.String("appids", "", "Comma separated list of appIds that should be processed")
 	flag.Parse()
 	if flag.NArg() == 1 {
 		steamDir = &flag.Args()[0]
@@ -153,7 +154,7 @@ func startApplication() {
 			errorAndExit(err)
 		}
 
-		games := GetGames(user, *nonSteamOnly)
+		games := GetGames(user, *nonSteamOnly, *appIDs)
 
 		fmt.Println("Loading existing images and backups...")
 


### PR DESCRIPTION
Comma separated list of appids that will be processed

Resolves #75 

I'm looking into a different feature (a sort of "reverttosteam" flag that gets rid of custom artworks if an official one from Steam exists, would be used together with "onlymissingartworks" from the other pull request to populate the missing ones but be able to easily switch back to official ones when they get added) and this seemed to be useful for testing and a bit of practice (first time I'm doing anything with Go) :)

Hopefully I haven't overlooked anything.