### PR TITLE
Auto link the latest builds download.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ again when you get more games or want to update the category overlays.
 
 # Download #
 
-[**steamgrid-windows.zip (4.4MB)**](https://github.com/boppreh/steamgrid/releases/download/v3.1.0/steamgrid_windows.zip)
+[**steamgrid-windows.zip (4.4MB)**](https://github.com/boppreh/steamgrid/releases/latest/download/steamgrid_windows.zip)
 
-[**steamgrid-linux.zip (4.5MB)**](https://github.com/boppreh/steamgrid/releases/download/v3.1.0/steamgrid_linux.zip)
+[**steamgrid-linux.zip (4.5MB)**](https://github.com/boppreh/steamgrid/releases/latest/download/steamgrid_linux.zip)
 
-[**steamgrid-mac.zip (4.6MB)**](https://github.com/boppreh/steamgrid/releases/download/v3.1.0/steamgrid_mac.zip)
+[**steamgrid-mac.zip (4.6MB)**](https://github.com/boppreh/steamgrid/releases/latest/download/steamgrid_mac.zip)
 
 # How to use #
 


### PR DESCRIPTION
https://help.github.com/en/github/administering-a-repository/linking-to-releases
I tend to do a lot of PR like these during those last days. It my third one now.
Basically, this type of linking allows you to let Github download the latest release which correspond to that archive name as steamgrid_*OS.zip according to which link you use.
Of course, If you do beta releases which follows the same name, It will download them. Changing the naming schemes of the releases archives break the link of course, if you don't change accordingly, but you should have any issues for anymore, having to update the README.md at each releases.