### PR TITLE
Point direct downloads in README to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ again when you get more games or want to update the category overlays.
 
 # Download #
 
-[**steamgrid-windows.zip (4.4MB)**](https://github.com/boppreh/steamgrid/releases/download/v3.1.0/steamgrid_windows.zip)
+[**steamgrid-windows.zip (4.4MB)**](https://github.com/boppreh/steamgrid/releases/latest/download/steamgrid_windows.zip)
 
-[**steamgrid-linux.zip (4.5MB)**](https://github.com/boppreh/steamgrid/releases/download/v3.1.0/steamgrid_linux.zip)
+[**steamgrid-linux.zip (4.5MB)**](https://github.com/boppreh/steamgrid/releases/latest/download/steamgrid_linux.zip)
 
-[**steamgrid-mac.zip (4.6MB)**](https://github.com/boppreh/steamgrid/releases/download/v3.1.0/steamgrid_mac.zip)
+[**steamgrid-mac.zip (4.6MB)**](https://github.com/boppreh/steamgrid/releases/latest/download/steamgrid_mac.zip)
 
 # How to use #
 


### PR DESCRIPTION
I noticed the direct downloads were pointing to an old version - 3.1.0 - even though 3.2.0 is available.

This change will have the links always point to the latest release, rather than a hard-coded version that has to be updated manually.