### PR TITLE
Fix non-steam shortcut match pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,7 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+Steam
+steamgrid*
+__debug_bin

--- a/games.go
+++ b/games.go
@@ -111,7 +111,7 @@ func addNonSteamGames(user User, games map[string]*Game) {
 
 	// The actual binary format is known, but using regexes is way easier than
 	// parsing the entire file. If I run into any problems I'll replace this.
-	gamePattern := regexp.MustCompile("(?i)\x00\x01appname\x00([^\x08]+?)\x00\x01exe\x00([^\x08]+?)\x00\x01[^\x08]+?\x00tags\x00(?:\x01([^\x08]+?)|)\x08\x08")
+	gamePattern := regexp.MustCompile("(?i)\x01appname\x00([^\x08]+?)\x00\x01exe\x00([^\x08]+?)\x00\x01.+?\x00tags\x00(?:\x01([^\x08]+?)|)\x08\x08")
 	tagsPattern := regexp.MustCompile("\\d\x00([^\x00\x01\x08]+?)\x00")
 	for _, gameGroups := range gamePattern.FindAllSubmatch(shortcutBytes, -1) {
 		gameName := gameGroups[1]


### PR DESCRIPTION
Adjusts the regex for non-Steam shortcut game matches to account for changes in the `shortcuts.vdf` file format as of the Steam stable client update (Dec. 20, 2020).