### PR TITLE
Update igdb to api v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ again when you get more games or want to update the category overlays.
     * Add the extension `.logo`/`_hero` before the image extension for logo art `Psychonauts.logo.png`, `3830_logo.png`
 4. *(optional)* Generate a some API Keys to enhance the automatic search:
     * [SteamGridDB API Key](https://www.steamgriddb.com/profile/preferences)
-    * [IGDB API Key](https://api.igdb.com/signup)
+    * [IGDB API Client/Secret](https://api-docs.igdb.com/#about)
 5. Run `steamgrid` and wait. No, really, it's all automatic. Not a single keypress required.
     * *(optional)* Append `--steamgriddb <api key>` if you've generated one before.
-    * *(optional)* Append `--igdb <api key>` if you've genereated one before.
+    * *(optional)* Append `--igdbclient <igdb client>` if you've genereated one before.
+    * *(optional)* Append `--igdbsecret <igdb secret>` if you've genereated one before.
     * *(optional)* Append `--types <preference>` to choose your preferences between animated steam covers or static ones Available choices : `animated`,`static`. Default : `static`. You can use `animated,static` to download both while preferring animated covers, and `static,animated` for preferring static covers.
     * *(optional)* Append `--styles <preference>` to choose your preferences between the different covers styles from steamgriddb. Available choices : `material`,`white_logo`,`alternate`,`blurred`,`no_logo`. Default: `alternate`. You can also input multiple comma-separated choices in the same manners of the `--types` argument.
     * *(optional)* Append `--appids <appid1,appid2>` to only process the specified appID(s)

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -29,7 +29,8 @@ func main() {
 
 func startApplication() {
 	steamGridDBApiKey := flag.String("steamgriddb", "", "Your personal SteamGridDB api key, get one here: https://www.steamgriddb.com/profile/preferences")
-	IGDBApiKey := flag.String("igdb", "", "Your personal IGDB api key, get one here: https://api.igdb.com/signup")
+	IGDBSecret := flag.String("igdbsecret", "", "Your personal IGDB api key, get one here: https://api.igdb.com/signup")
+	IGDBClient := flag.String("igdbclient", "", "Your personal IGDB api key, get one here: https://api.igdb.com/signup")
 	steamDir := flag.String("steamdir", "", "Path to your steam installation")
 	// "alternate" "blurred" "white_logo" "material" "no_logo"
 	steamGridDBStyles := flag.String("styles", "alternate", "Comma separated list of styles to download from SteamGridDB.\nExample: \"white_logo,material\"")
@@ -200,7 +201,7 @@ func startApplication() {
 				// Download if missing.
 				///////////////////////
 				if game.ImageSource == "" {
-					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, *IGDBApiKey, *skipGoogle, *onlyMissingArtwork)
+					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, *IGDBSecret, *IGDBClient, *skipGoogle, *onlyMissingArtwork)
 					if err != nil && err.Error() == "SteamGridDB authorization token is missing or invalid" {
 						// Wrong api key
 						*steamGridDBApiKey = ""


### PR DESCRIPTION
This should enable IGDB again, you need to create api tokens trough a twitch application tough.
Instead of the IGDBApi key as a launch parameter now you have IGDBClient and IGDBSecret