### PR TITLE
Fix some non-steam shortcuts being skipped

### DIFF
--- a/games.go
+++ b/games.go
@@ -114,7 +114,7 @@ func addNonSteamGames(user User, games map[string]*Game) {
 
 	// The actual binary format is known, but using regexes is way easier than
 	// parsing the entire file. If I run into any problems I'll replace this.
-	gamePattern := regexp.MustCompile("(?i)\x00\x02appid\x00(.{4})\x01appname\x00([^\x08]+?)\x00\x01exe\x00([^\x08]+?)\x00\x01.+?\x00tags\x00(?:\x01([^\x08]+?)|)\x08\x08")
+	gamePattern := regexp.MustCompile("(?i)\x00\x02appid\x00(.{1,4})\x01appname\x00([^\x08]+?)\x00\x01exe\x00([^\x08]+?)\x00\x01.+?\x00tags\x00(?:\x01([^\x08]+?)|)\x08\x08")
 	tagsPattern := regexp.MustCompile("\\d\x00([^\x00\x01\x08]+?)\x00")
 	for _, gameGroups := range gamePattern.FindAllSubmatch(shortcutBytes, -1) {
 		gameID := fmt.Sprint(binary.LittleEndian.Uint32(gameGroups[1]))


### PR DESCRIPTION
Regex expression parsing shortcuts.vfd file has been modified so it doesn't skip shortcuts where 4-byte appid is translated into less-than-4 character UTF-8 text.
Before fix: appid had to be matched to exactly 4 characters. But regexp matches UTF-8 so sometimes it could be 1,2 or 3 characters.
After fix: appid is matched to an UTF-8 text of 1 to 4 characters. Matched byte length of appid is always 4.

Fixes #110.