### PR TITLE
Handle WEBP animations.

### DIFF
--- a/steamgrid.go
+++ b/steamgrid.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -25,6 +27,24 @@ func errorAndExit(err error) {
 func main() {
 	http.DefaultTransport.(*http.Transport).ResponseHeaderTimeout = time.Second * 10
 	startApplication()
+}
+
+func bToMb(b uint64) uint64 {
+	return b / 1024 / 1024
+}
+
+func printMemStats(endline ...bool) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
+	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
+	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
+	//fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
+	//fmt.Printf("\tNumGC = %v", m.NumGC)
+
+	if len(endline) == 0 || endline[0] {
+		fmt.Printf("\n")
+	}
 }
 
 func startApplication() {
@@ -180,6 +200,7 @@ func startApplication() {
 			} else {
 				name = "unknown game with id " + game.ID
 			}
+
 			fmt.Printf("Processing %v (%v/%v)\n", name, i, len(games))
 
 			for artStyle, artStyleExtensions := range artStyles {
@@ -257,6 +278,10 @@ func startApplication() {
 				err = backupGame(gridDir, game, artStyleExtensions)
 				if err != nil {
 					errorAndExit(err)
+				}
+
+				if strings.Contains(game.ImageExt, "webp") {
+					game.ImageExt = ".png"
 				}
 
 				imagePath := filepath.Join(gridDir, game.ID+artStyleExtensions[0]+game.ImageExt)


### PR DESCRIPTION
Requires use of a package [github.com/kmicki/webpanimation](github.com/kmicki/webpanimation) which is forked from [github.com/size-of-int/webpanimation](github.com/size-of-int/webpanimation). The fork adds necessary functions for decoding **WEBP** animation into single frames (original package only supports encoding single frames into an animation).

The **webpanimation** package uses **cgo** to bind to libwebp, so **gcc** is necessary to build the application from now on.

It is working on Linux (tested on Arch/SteamOS) and Windows (tested on Windows 10 with **mingw** installed). It was not tested on a Mac but should also work.

The extension is changed to *.png* when the file is saved anyway, otherwise Steam will not use it.
But it works with a changed extension.