### PR TITLE
Additional optional command-line flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ again when you get more games or want to update the category overlays.
     * *(optional)* Append `-skip<preference>` to skip searching and downloading parts from certain artwork elements. Available choices : `-skipbanner`,`-skipcover`,`-skiphero`,`-skiplogo`. For example: Appending `-skiplogo -skipbanner` will prevent steamgrid to search and download logo and banners for any games.
     * *(optional)* Append `-skipsteam` to not download the default artworks from Steam.
     * *(optional)* Append `-skipgoogle` to skip search and downloads from Google.
+    * *(optional)* Append `--ignoreBackup` to ignore backups when looking for artwork
+    * *(optional)* Append `--ignoreManual` to ignore manual customization when looking for artwork
+    * *(optional)* Append `--skipCategory <category>` to skip processing of games assigned to a specific Steam category
+    * *(optional)* Append `--steamgriddbonly` to search for artwork only in SteamGridDB
     * *(tip)* Run with `--help` to see all available options again.
 6. Read the report and open Steam in grid view to check the results.
 

--- a/backup.go
+++ b/backup.go
@@ -95,7 +95,7 @@ func filterForImages(paths []string) []string {
 	return matchedPaths
 }
 
-func loadExisting(overridePath string, gridDir string, game *Game, artStyleExtensions []string) {
+func loadExisting(overridePath string, gridDir string, game *Game, artStyleExtensions []string, ignoreBackup bool, ignoreManual bool) {
 	overridenIDs, _ := filepath.Glob(filepath.Join(overridePath, game.ID+artStyleExtensions[0]+".*"))
 	if overridenIDs != nil && len(overridenIDs) > 0 {
 		loadImage(game, "local file in directory 'games'", overridenIDs[0])
@@ -126,16 +126,18 @@ func loadExisting(overridePath string, gridDir string, game *Game, artStyleExten
 	files, err := filepath.Glob(filepath.Join(gridDir, game.ID+artStyleExtensions[0]+".*"))
 	files = filterForImages(files)
 	if err == nil && len(files) > 0 {
-		err = loadImage(game, "manual customization", files[0])
-		if err == nil {
-			// set as overlay to check for hash in getBackupPath()
-			game.OverlayImageBytes = game.CleanImageBytes
+		if !ignoreManual {
+			err = loadImage(game, "manual customization", files[0])
+			if err == nil && !ignoreBackup {
+				// set as overlay to check for hash in getBackupPath()
+				game.OverlayImageBytes = game.CleanImageBytes
 
-			// See if there exists a backup image with no overlays or modifications.
-			loadImage(game, "backup", getBackupPath(gridDir, game, artStyleExtensions))
+				// See if there exists a backup image with no overlays or modifications.
+				loadImage(game, "backup", getBackupPath(gridDir, game, artStyleExtensions))
 
-			// remove overlay
-			game.OverlayImageBytes = nil
+				// remove overlay
+				game.OverlayImageBytes = nil
+			}
 		}
 	}
 

--- a/download.go
+++ b/download.go
@@ -175,7 +175,7 @@ func getSteamGridDBImage(game *Game, artStyleExtensions []string, steamGridDBApi
 
 		// Authorization token is missing or invalid
 		if err != nil && err.Error() == "401" {
-			return "", errors.New("SteamGridDB authorization token is missing or invalid")
+			return "", errors.New(" SteamGridDB authorization token is missing or invalid")
 			// Could not find game with that id
 		} else if err != nil && err.Error() == "404" {
 			// Try searching for the name…
@@ -356,9 +356,9 @@ const steamCdnURLFormat = `cdn.akamai.steamstatic.com/steam/apps/%v/`
 // sources. Returns the final response received and a flag indicating if it was
 // from a Google search (useful because we want to log the lower quality
 // images).
-func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, IGDBSecret string, IGDBClient string, skipGoogle bool, onlyMissingArtwork bool) (response *http.Response, from string, err error) {
+func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, IGDBSecret string, IGDBClient string, skipGoogle bool, onlyMissingArtwork bool, steamGridDBOnly bool) (response *http.Response, from string, err error) {
 	from = "steam server"
-	if !skipSteam {
+	if !skipSteam && !steamGridDBOnly {
 		response, err = tryDownload(fmt.Sprintf(akamaiURLFormat+artStyleExtensions[2], game.ID))
 		if err == nil && response != nil {
 			if onlyMissingArtwork {
@@ -388,7 +388,7 @@ func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []stri
 	}
 
 	// IGDB has mostly cover styles
-	if artStyle == "Cover" && IGDBClient != "" && IGDBSecret != "" && url == "" {
+	if artStyle == "Cover" && IGDBClient != "" && IGDBSecret != "" && url == "" && !steamGridDBOnly {
 		from = "IGDB"
 		url, err = getIGDBImage(game.Name, IGDBSecret, IGDBClient)
 		if err != nil {
@@ -397,7 +397,7 @@ func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []stri
 	}
 
 	// Skip for Covers, bad results
-	if !skipGoogle && artStyle == "Banner" && url == "" {
+	if !skipGoogle && artStyle == "Banner" && url == "" && !steamGridDBOnly {
 		from = "search"
 		url, err = getGoogleImage(game.Name, artStyleExtensions)
 		if err != nil {
@@ -416,8 +416,8 @@ func getImageAlternatives(game *Game, artStyle string, artStyleExtensions []stri
 // DownloadImage tries to download the game images, saving it in game.ImageBytes. Returns
 // flags indicating if the operation succeeded and if the image downloaded was
 // from a search.
-func DownloadImage(gridDir string, game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, IGDBSecret string, IGDBClient string, skipGoogle bool, onlyMissingArtwork bool) (string, error) {
-	response, from, err := getImageAlternatives(game, artStyle, artStyleExtensions, skipSteam, steamGridDBApiKey, IGDBSecret, IGDBClient, skipGoogle, onlyMissingArtwork)
+func DownloadImage(gridDir string, game *Game, artStyle string, artStyleExtensions []string, skipSteam bool, steamGridDBApiKey string, IGDBSecret string, IGDBClient string, skipGoogle bool, onlyMissingArtwork bool, steamGridDBOnly bool) (string, error) {
+	response, from, err := getImageAlternatives(game, artStyle, artStyleExtensions, skipSteam, steamGridDBApiKey, IGDBSecret, IGDBClient, skipGoogle, onlyMissingArtwork, steamGridDBOnly)
 	if response == nil || err != nil {
 		return "", err
 	}

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -51,6 +51,10 @@ func startApplication() {
 	nonSteamOnly := flag.Bool("nonsteamonly", false, "Only search artwork for Non-Steam-Games")
 	appIDs := flag.String("appids", "", "Comma separated list of appIds that should be processed")
 	onlyMissingArtwork := flag.Bool("onlymissingartwork", false, "Only download artworks missing on the official servers")
+	ignoreBackup := flag.Bool("ignorebackup", false, "Ignore backups when looking for artwork")
+	ignoreManual := flag.Bool("ignoremanual", false, "Ignore manual customization when looking for artwork")
+	skipCategory := flag.String("skipcategory", "", "Name of the category with games to skip during processing")
+	steamgriddbonly := flag.Bool("steamgriddbonly", false, "Search for artwork only in SteamGridDB")
 	flag.Parse()
 	if flag.NArg() == 1 {
 		steamDir = &flag.Args()[0]
@@ -162,7 +166,7 @@ func startApplication() {
 			errorAndExit(err)
 		}
 
-		games := GetGames(user, *nonSteamOnly, *appIDs)
+		games := GetGames(user, *nonSteamOnly, *appIDs, *skipCategory)
 
 		fmt.Println("Loading existing images and backups...")
 
@@ -190,7 +194,7 @@ func startApplication() {
 				game.OverlayImageBytes = nil
 
 				overridePath := filepath.Join(filepath.Dir(os.Args[0]), "games")
-				loadExisting(overridePath, gridDir, game, artStyleExtensions)
+				loadExisting(overridePath, gridDir, game, artStyleExtensions, *ignoreBackup, *ignoreManual)
 				// This cleans up unused backups and images for the same game but with different extensions.
 				err = removeExisting(gridDir, game.ID, artStyleExtensions)
 				if err != nil {
@@ -201,8 +205,8 @@ func startApplication() {
 				// Download if missing.
 				///////////////////////
 				if game.ImageSource == "" {
-					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, *IGDBSecret, *IGDBClient, *skipGoogle, *onlyMissingArtwork)
-					if err != nil && err.Error() == "SteamGridDB authorization token is missing or invalid" {
+					from, err := DownloadImage(gridDir, game, artStyle, artStyleExtensions, *skipSteam, *steamGridDBApiKey, *IGDBSecret, *IGDBClient, *skipGoogle, *onlyMissingArtwork, *steamgriddbonly)
+					if err != nil && err.Error() == " SteamGridDB authorization token is missing or invalid" {
 						// Wrong api key
 						*steamGridDBApiKey = ""
 						fmt.Println(err.Error())


### PR DESCRIPTION
Added 4 optional command-line flags:

  * *(optional)* Append `--ignoreBackup` to ignore backups when looking for artwork
  * *(optional)* Append `--ignoreManual` to ignore manual customization when looking for artwork
  * *(optional)* Append `--skipCategory <category>` to skip processing of games assigned to a specific Steam category
  * *(optional)* Append `--steamgriddbonly` to search for artwork only in SteamGridDB