### PR TITLE
Ignore anonymous userdata folder

### DIFF
--- a/users.go
+++ b/users.go
@@ -39,6 +39,13 @@ func GetUsers(installationDir string) ([]User, error) {
 		userID := userDir.Name()
 		userDir := filepath.Join(userdataDir, userID)
 
+		// Ignore anonymous userdata folder because it's only used for CLI downloads 
+		// and it doesn't have required localconfig.vdf fields
+		userDirName := filepath.Base(userDir)
+		if (userDirName == "anonymous") {
+			continue
+		}
+		
 		configFile := filepath.Join(userDir, "config", "localconfig.vdf")
 		// Malformed user directory. Without the localconfig file we can't get
 		// the username and the game list, so we skip it.


### PR DESCRIPTION
The app crashes when trying to read [`anonymous`](https://developer.valvesoftware.com/wiki/SteamCMD#Anonymous) user config file, 'cause it doesn't have required `PersonaName` field 

```
Loading overlays...
Loaded 6 overlays. 

You can find many user-created overlays at https://www.reddit.com/r/steamgrid/wiki/overlays .

Looking for Steam directory...
If SteamGrid doesn´t find the directory automatically, launch it with an argument linking to the Steam directory.
Loading users...
Setting permission...
Setting permission...
Setting permission...
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
main.GetUsers({0x9c1aa60, 0x1a})
        C:/Users/BoppreH/Desktop/source/steamgrid/users.go:68 +0x66f
main.startApplication()
        C:/Users/BoppreH/Desktop/source/steamgrid/steamgrid.go:114 +0x13ff
main.main()
        C:/Users/BoppreH/Desktop/source/steamgrid/steamgrid.go:27 +0x44
```

Also, it doesn't make sense to fetch grids for `anonymous` user, since the only purpose for it is to download CLI game servers. 

This PR adds a check to exclude `anonymous` folder from user parsing, and it should fix crash issue