### PR TITLE
Steam Web API support

### DIFF
--- a/steamgrid.go
+++ b/steamgrid.go
@@ -51,6 +51,7 @@ func startApplication() {
 	nonSteamOnly := flag.Bool("nonsteamonly", false, "Only search artwork for Non-Steam-Games")
 	appIDs := flag.String("appids", "", "Comma separated list of appIds that should be processed")
 	onlyMissingArtwork := flag.Bool("onlymissingartwork", false, "Only download artworks missing on the official servers")
+	apiKey := flag.String("apikey", "", "Steam Web API key to use for game list request")
 	flag.Parse()
 	if flag.NArg() == 1 {
 		steamDir = &flag.Args()[0]
@@ -162,7 +163,7 @@ func startApplication() {
 			errorAndExit(err)
 		}
 
-		games := GetGames(user, *nonSteamOnly, *appIDs)
+		games := GetGames(user, *nonSteamOnly, *appIDs, *apiKey)
 
 		fmt.Println("Loading existing images and backups...")
 

--- a/users.go
+++ b/users.go
@@ -84,7 +84,9 @@ func GetUsers(installationDir string) ([]User, error) {
 }
 
 // URL to get the game list from the SteamId64.
-const profilePermalinkFormat = `http://steamcommunity.com/profiles/%v/games?xml=1`
+const profileCommunityFormat = `http://steamcommunity.com/profiles/%v/games?xml=1`
+// URL to get the game list from the Steam Web API using an API key
+const profileWebApiFormat = `https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=%v&steamid=%v&include_played_free_games=true&include_appinfo=true&format=json`
 
 // The Steam website has the terrible habit of returning 200 OK when requests
 // fail, and signaling the error in HTML. So we have to parse the request to
@@ -93,8 +95,14 @@ const profilePermalinkFormat = `http://steamcommunity.com/profiles/%v/games?xml=
 const steamProfileErrorMessage = `The specified profile could not be found.`
 
 // GetProfile returns the HTML profile from a user from their SteamId32.
-func GetProfile(user User) (string, error) {
-	response, err := http.Get(fmt.Sprintf(profilePermalinkFormat, user.SteamID64))
+func GetProfile(user User, apiKey string) (string, error) {
+	var response *http.Response
+	var err error
+	if len(apiKey) > 0 {
+		response, err = http.Get(fmt.Sprintf(profileWebApiFormat, apiKey, user.SteamID64))
+	} else {
+		response, err = http.Get(fmt.Sprintf(profileCommunityFormat, user.SteamID64))
+	}
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Use the modern Steam web API if an [API key](https://steamcommunity.com/dev/apikey) is provided via the `-apikey` argument.
This provides future-proofing if the deprecated Community API is ever deactivated, and can read private game lists if the API key belongs to the same user.